### PR TITLE
use FLINT bigint library to replace `BigInt`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,14 @@ repo = "https://github.com/KlausC/CommutativeRings.jl"
 version = "0.6.0"
 
 [deps]
+FLINT_jll = "e134572f-a0d5-539d-bddf-3cad8db41a82"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Aqua = "0.8"
+FLINT_jll = "300.100"
 LinearAlgebra = "1"
 Polynomials = "1,2,3,4"
 Primes = "0.5"

--- a/src/CommutativeRings.jl
+++ b/src/CommutativeRings.jl
@@ -4,10 +4,17 @@ using LinearAlgebra
 using Base.Checked
 using Primes
 using Random
+using FLINT_jll
+
+const libflint = FLINT_jll.libflint
+
+function flint_abort()
+  error("Problem in the Flint-Subsystem")
+end
 
 export category_trait, isfield
 export Ring, RingInt, FractionRing, QuotientRing, Polynomial
-export ZZ, QQ, ZZmod, Frac, Quotient, UnivariatePolynomial, MultivariatePolynomial
+export ZZ, ZZZ, ZI, QQ, ZZmod, Frac, Quotient, UnivariatePolynomial, MultivariatePolynomial
 export GaloisField, FSeries
 
 export SpecialPowerSeries, PowerSeries, O, precision, absprecision
@@ -62,6 +69,7 @@ include("typevars.jl")
 include("promoteconvert.jl")
 include("generic.jl")
 include("zz.jl")
+include("zzflint.jl")
 include("qq.jl")
 include("zzmod.jl")
 include("quotient.jl")

--- a/src/algebraic.jl
+++ b/src/algebraic.jl
@@ -448,6 +448,9 @@ function Base.tanpi(q::QQ)
     AlgebraicNumber(_squaremulim(minimal_polynomial(ac)), approx(ac) / im)
 end
 
+# only for internal usage
+# assume minimal polynomial has only powers of x^2.
+# simulate effect of multiplication with `im` in minimal polynomial
 function _squaremulim(p::UnivariatePolynomial)
     c = copy(p)
     n = length(c.coeff)

--- a/src/algebraic.jl
+++ b/src/algebraic.jl
@@ -1,6 +1,6 @@
 
 import Base: *, /, inv, +, -, sqrt, ^, literal_pow, iszero, zero, one, ==, isapprox, hash
-import Base: conj, real, imag, abs, copy, isreal
+import Base: conj, real, imag, abs, copy, isreal, cispi, cospi, sinpi, tanpi
 
 # construction
 basetype(::Type{<:AlgebraicNumber}) = QQ{BigInt}
@@ -160,14 +160,11 @@ function root(a::AlgebraicNumber, n::Integer)
     AlgebraicNumber(p, approx(a)^(1 // n))
 end
 
-# The imaginary constant a algebraic number
-IM() = AlgebraicNumber(monom(QQ{Int}[:x], 2) + 1, im)
-
 sqrt(a::AlgebraicNumber) = ^(a, 1 // 2)
 # cbrt(a::AlgebraicNumber) = ^(a, 1 // 3) # intentionally not defined - alike Complex.
 isreal(a::AlgebraicNumber) = isreal(approx(a))
 real(a::AlgebraicNumber) = isreal(a) ? a : (a + conj(a)) / 2
-imag(a::AlgebraicNumber) = isreal(a) ? zero(a) : (conj(a) - a) * IM() / 2
+imag(a::AlgebraicNumber) = isreal(a) ? zero(a) : (conj(a) - a) * AlgebraicNumber(im) / 2
 abs(a::AlgebraicNumber) = !isreal(a) ? sqrt(a * conj(a)) : real(approx(a)) >= 0 ? a : -a
 
 function *(a::T, b::T) where T<:AlgebraicNumber
@@ -427,8 +424,8 @@ function Base.sinpi(q::QQ)
     b = inv(a)
     s = (a - b) / 2
     fs = sinpi(big(value(q))) * im
-    as = AlgebraicNumber(s, fs) / IM()
-    as
+    as = AlgebraicNumber(s, fs)
+    AlgebraicNumber(_squaremulim(minimal_polynomial(as)), approx(as) / im)
 end
 function Base.cospi(q::QQ)
     d = cispi(q)
@@ -440,6 +437,26 @@ function Base.cospi(q::QQ)
     ac = AlgebraicNumber(c, fc)
     ac
 end
+function Base.tanpi(q::QQ)
+    d = cispi(q)
+    N = NF(d)
+    a = monom(N)
+    b = inv(a)
+    c = (a - b) / (a + b)
+    fc = tanpi(big(value(q))) * im
+    ac = AlgebraicNumber(c, fc)
+    AlgebraicNumber(_squaremulim(minimal_polynomial(ac)), approx(ac) / im)
+end
+
+function _squaremulim(p::UnivariatePolynomial)
+    c = copy(p)
+    n = length(c.coeff)
+    for k = n-2:-4:1
+        c.coeff[k] = -c.coeff[k]
+    end
+    c
+end
+
 
 """
     rationalconst(expr)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -47,6 +47,7 @@ Base.map(f, a::Ring, bs::Ring...) = f(a, bs...)
 basetype(::T) where T<:Ring = basetype(T)
 basetype(::Type{T}) where T = Union{}
 basetype(::Type{Union{}}) = Union{}
+basetype(::Type{Rational{S}}) where S = S
 
 depth(::Type{Union{}}) = -1
 depth(::Type) = 0

--- a/src/promoteconvert.jl
+++ b/src/promoteconvert.jl
@@ -1,18 +1,18 @@
 
 # promotions
 
-_xpromote_rule(::Type{T}, ::Type{S}) where {T<:Ring,S<:RingInt} = begin
+function promote_rule(::Type{T}, ::Type{S}) where {T<:Ring,S<:RingInt}
     depth(T) < depth(S) && return Base.Bottom
     B = basetype(T)
     (S <: T || S <: B) ? T : promote_type(B, S) == B ? T : Base.Bottom
 end
 _xpromote_rule(a::Type, b::Type) = promote_type(a, b)
-
+#=
 @generated function Base.promote_rule(a::Type{<:Ring}, b::Type{<:RingInt})
     bt = _xpromote_rule(a.parameters[1], b.parameters[1])
     :($bt)
 end
-
+=#
 function promote_rule(::Type{R}, ::Type{S}) where {R<:Ring,S<:Rational}
     promote_rule(R, promote_type(basetype(R), S))
 end

--- a/src/ringtypes.jl
+++ b/src/ringtypes.jl
@@ -80,6 +80,55 @@ struct ZZ{T<:Signed} <: Ring{ZZClass{T}}
     ZZ(val::T) where T<:Signed = ZZ{T}(val)
 end
 
+mutable struct ZZZ <: Ring{ZZClass{Integer}}
+    d::Int
+
+    function ZZZ(x::ZZZ)
+        z = new()
+        ccall((:fmpz_init_set, libflint), Nothing, (Ref{ZZZ}, Ref{ZZZ}), z, x)
+        finalizer(_fmpz_clear_fn, z)
+        return z
+    end
+
+    function ZZZ(x::Int)
+        z = new()
+        ccall((:fmpz_init_set_si, libflint), Nothing, (Ref{ZZZ}, Int), z, x)
+        finalizer(_fmpz_clear_fn, z)
+        return z
+    end
+
+    function ZZZ(x::UInt)
+        z = new()
+        ccall((:fmpz_init_set_ui, libflint), Nothing, (Ref{ZZZ}, UInt), z, x)
+        finalizer(_fmpz_clear_fn, z)
+        return z
+    end
+
+    function ZZZ(x::BigInt)
+        z = new()
+        ccall((:fmpz_init, libflint), Nothing, (Ref{ZZZ},), z)
+        ccall((:fmpz_set_mpz, libflint), Nothing, (Ref{ZZZ}, Ref{BigInt}), z, x)
+        finalizer(_fmpz_clear_fn, z)
+        return z
+    end
+
+    function ZZZ(x::Float64)
+        !isinteger(x) && throw(InexactError(:convert, ZZZ, x))
+        z = new()
+        ccall((:fmpz_init, libflint), Nothing, (Ref{ZZZ},), z)
+        ccall((:fmpz_set_d, libflint), Nothing, (Ref{ZZZ}, Cdouble), z, x)
+        finalizer(_fmpz_clear_fn, z)
+        return z
+    end
+
+end
+
+const ZI = Union{ZZ,ZZZ}
+
+function _fmpz_clear_fn(a::ZZZ)
+   ccall((:fmpz_clear, libflint), Nothing, (Ref{ZZZ},), a)
+end
+
 """
     ZZmod{m,S<:Integer}
 
@@ -98,7 +147,7 @@ The ring of fractions of `R`. The elements consist of pairs `num::R,den::R`.
 During creation the values may be canceled to achieve `gcd(num, den) == one(R)`.
 The special case of `R<:Integer` is handled by `QQ{R}`.
 """
-struct Frac{P<:Union{Polynomial,ZZ}} <: FractionRing{P,FractionClass{P}}
+struct Frac{P<:Union{Polynomial,ZI}} <: FractionRing{P,FractionClass{P}}
     num::P
     den::P
     Frac{P}(num::P, den::P, ::NCT) where P = new{P}(num, den)

--- a/src/univarpolynom.jl
+++ b/src/univarpolynom.jl
@@ -99,6 +99,8 @@ function _promote_rule(::Type{UnivariatePolynomial{R,X}}, ::Type{S}) where {X,R,
 end
 promote_rule(::Type{UnivariatePolynomial{R,X}}, ::Type{S}) where {X,R,S<:Integer} =
     UnivariatePolynomial{promote_type(R, S),X}
+promote_rule(::Type{UnivariatePolynomial{R,X}}, ::Type{S}) where {X,R,S<:ZI} =
+        UnivariatePolynomial{promote_type(R, S),X}
 promote_rule(::Type{UnivariatePolynomial{R,X}}, ::Type{S}) where {X,R,S<:Rational} =
     UnivariatePolynomial{promote_type(R, S),X}
 
@@ -770,7 +772,7 @@ end
 
 import Base: show
 
-issimple(::Union{ZZ,ZZmod,QQ,Number}) = true
+issimple(::Union{ZZ,ZZmod,QQ,Number,ZZZ}) = true
 issimple(::Quotient{<:UnivariatePolynomial{S,:γ}}) where S = true
 issimple(p::Polynomial) = ismonom(p)
 issimple(::Any) = false

--- a/src/zz.jl
+++ b/src/zz.jl
@@ -22,7 +22,7 @@ function ZZ{T}(a::Union{QQ{T},Frac{ZZ{T}}}) where T
     ZZ(a.num)
 end
 ZZ(a::Union{QQ{T},Frac{ZZ{T}}}) where T = ZZ{T}(a)
-ZZ{S}(a::Union{QQ{T},Frac{ZZ{T}}}) where {S,T} = ZZ(promote_type(S,T)(a))
+ZZ{S}(a::Union{QQ{T},Frac{ZZ{T}}}) where {S,T} = ZZ(promote_type(S, T)(a))
 
 # promotion and conversion
 promote_rule(::Type{ZZ{T}}, ::Type{ZZ{S}}) where {S,T} = ZZ{promote_type(S, T)}
@@ -76,3 +76,5 @@ Base.show(io::IO, z::ZZ) = print(io, z.val)
 function (::Type{T})(a::ZZ) where T<:Integer
     T(value(a))
 end
+
+wide_type(::Type{<:ZZ}) = ZZ{BigInt}

--- a/src/zzflint.jl
+++ b/src/zzflint.jl
@@ -1,0 +1,224 @@
+
+import Base: ==, !=, <=, >=, <, >, &, xor, |
+
+wide_type(::Type{ZZZ}) = ZZZ
+Base.signbit(a::ZZZ) = a < 0
+
+# construction
+category_trait(::Type{<:ZZZ}) = EuclidianDomainTrait
+basetype(::Type{<:ZZZ}) = BigInt
+
+Base.IteratorSize(::Type{<:ZZZ}) = Base.IsInfinite()
+lcunit(a::Z) where Z<:ZZZ = a < 0 ? -one(a) : one(a)
+issimpler(a::T, b::T) where T<:ZZZ = abs(a) < abs(b)
+iscoprime(a::T, b::T) where T<:ZZZ = gcd(a, b) == one(T)
+value(a::ZZZ) = BigInt(a)
+
+copy(a::ZZZ) = ZZZ(a)
+ZZZ(a::T) where T<:Base.BitSignedSmall = ZZZ(Int(a))
+ZZZ(a::T) where T<:Base.BitUnsignedSmall = ZZZ(UInt(a))
+ZZZ(a::T) where T<:Base.BitInteger = ZZZ(BigInt(a))
+ZZZ(a::T) where T<:Real = ZZZ(Integer(a))
+
+function ZZZ(a::Union{QQ{T},Frac{ZZ{T}}}) where T
+    a.den != 1 && throw(InexactError(:ZZZ, ZZZ, a))
+    ZZZ(a.num)
+end
+
+# promotion and conversion
+promote_rule(::Type{ZZZ}, ::Type{<:ZZ}) = ZZZ
+promote_rule(::Type{ZZZ}, ::Type{QQ{S}}) where {S} = QQ{promote_type(S, BigInt)}
+promote_rule(::Type{ZZZ}, ::Type{S}) where {S<:Integer} = ZZZ
+promote_rule(::Type{ZZZ}, ::Type{R}) where {R<:Rational} = QQ{promote_type(basetype(R), BigInt)}
+
+# induced homomorphism
+function (h::Hom{F,R,S})(p::Z) where {F,R,S,Z<:ZZZ}
+    Z(h.f(value(p)))
+end
+
+for op in (:+, :-, :*, :/, :div, :rem, :divrem, :gcd, :gcdx, :pgcd, :pgcdx)
+    @eval begin
+        ($op)(a::ZZZ, b::Integer) = ($op)(promote(a, b)...)
+        ($op)(a::Integer, b::ZZZ) = ($op)(promote(a, b)...)
+    end
+end
+
+Base.isless(p::T, q::T) where T<:ZZZ = p < q
+Base.to_power_type(x::ZZZ) = x
+
+# operations for ZZ
+
+fmpz(a::Symbol) = (Symbol(:fmpz_, a), libflint)
+
+for (fJ, fC) in ((:+, :add), (:-, :sub), (:*, :mul), (:&, :and), (:|, :or), (:xor, :xor))
+    @eval begin
+        function ($fJ)(x::ZZZ, y::ZZZ)
+            z = ZZZ(0)
+            ccall($(fmpz(fC)), Nothing, (Ref{ZZZ}, Ref{ZZZ}, Ref{ZZZ}), z, x, y)
+            return z
+        end
+        function ($fJ)(x::ZZZ, y::Int)
+            z = ZZZ(0)
+            ccall($(fmpz(Symbol(fC, "_si"))), Nothing, (Ref{ZZZ}, Ref{ZZZ}, Int), z, x, y)
+            return z
+        end
+        function ($fJ)(x::ZZZ, y::UInt)
+            z = ZZZ(0)
+            ccall($(fmpz(Symbol(fC, "_ui"))), Nothing, (Ref{ZZZ}, Ref{ZZZ}, UInt), z, x, y)
+            return z
+        end
+
+        function ($fJ)(y::Int, x::ZZZ)
+            z = ZZZ(0)
+            ccall($(fmpz(Symbol(fC, "_si"))), Nothing, (Ref{ZZZ}, Ref{ZZZ}, Int), z, x, y)
+            return $(fC == :sub) ? -z : z
+        end
+        function ($fJ)(y::UInt, x::ZZZ)
+            z = ZZZ(0)
+            ccall($(fmpz(Symbol(fC, "_ui"))), Nothing, (Ref{ZZZ}, Ref{ZZZ}, UInt), z, x, y)
+            return $(fC == :sub) ? -z : z
+        end
+    end
+end
+
+function -(a::ZZZ)
+    z = ZZZ(0)
+    ccall((:fmpz_neg, libflint), Nothing, (Ref{ZZZ}, Ref{ZZZ}), z, a)
+    return z
+end
+
+function abs(a::ZZZ)
+    z = ZZZ(0)
+    ccall((:fmpz_abs, libflint), Nothing, (Ref{ZZZ}, Ref{ZZZ}), z, a)
+    return z
+end
+
+^(a::ZZZ, b::Integer) = pow(a, b)
+^(a::ZZZ, b::ZZZ) = pow(a, b)
+
+function pow(a::ZZZ, b::T) where T<:Union{Integer,ZZZ}
+    z = ZZZ(0)
+    iszero(a) && return z
+    if isunit(a)
+        return !isone(a) && isodd(b) ? abs(a) : copy(a)
+    end
+    b < 0 && throw(DomainError(a, "cannot divide by non-unit."))
+    ccall((:fmpz_pow_ui, libflint), Nothing, (Ref{ZZZ}, Ref{ZZZ}, UInt), z, a, b)
+    return z
+end
+
+for (m, f) in ((RoundToZero, :t), (RoundDown, :f), (RoundUp, :c), (RoundNearest, :n))
+    @eval begin
+        function divrem(a::T, b::T, m::$(typeof(m))) where T<:ZZZ
+            q = ZZZ(0)
+            r = ZZZ(0)
+            ccall(
+                $(fmpz(Symbol(f, :div_qr))),
+                Nothing,
+                (Ref{ZZZ}, Ref{ZZZ}, Ref{ZZZ}, Ref{ZZZ}),
+                q,
+                r,
+                a,
+                b,
+            )
+            return q, r
+        end
+        function div(a::T, b::T, m::$(typeof(m))) where T<:ZZZ
+            q = ZZZ(0)
+            ccall(
+                $(fmpz(Symbol(f, :div_q))),
+                Nothing,
+                (Ref{ZZZ}, Ref{ZZZ}, Ref{ZZZ}),
+                q,
+                a,
+                b,
+            )
+            return q
+        end
+        function rem(a::T, b::T, m::$(typeof(m))) where T<:ZZZ
+            r = ZZZ(0)
+            ccall(
+                $(fmpz(Symbol(f, :div_r))),
+                Nothing,
+                (Ref{ZZZ}, Ref{ZZZ}, Ref{ZZZ}),
+                r,
+                a,
+                b,
+            )
+            return r
+        end
+    end
+end
+
+divrem(a::T, b::T) where T<:ZZZ = divrem(a, b, RoundToZero)
+div(a::T, b::T) where T<:ZZZ = div(a, b, RoundToZero)
+rem(a::T, b::T) where T<:ZZZ = rem(a, b, RoundToZero)
+
+isunit(a::ZZZ) = abs(a.d) == 1
+isone(a::ZZZ) = isone(a.d)
+iszero(a::ZZZ) = iszero(a.d)
+zero(::Type{ZZZ}) = ZZZ(0)
+one(::Type{ZZZ}) = ZZZ(1)
+hash(a::ZZZ, h::UInt) = hash(value(a), h)
+
+factor(a::ZZZ) = [ZZZ(first(x)) => last(x) for x in Primes.factor(value(a))]
+isirreducible(a::ZZZ) = isirreducible(value(a))
+
+Base.show(io::IO, z::ZZZ) = print(io, value(z))
+
+function (::Type{BigInt})(a::ZZZ)
+    r = BigInt()
+    ccall((:fmpz_get_mpz, libflint), Nothing, (Ref{BigInt}, Ref{ZZZ}), r, a)
+    return r
+end
+
+function (::Type{Int})(a::ZZZ)
+    (a > typemax(Int) || a < typemin(Int)) && throw(InexactError(:convert, Int, a))
+    return ccall((:fmpz_get_si, libflint), Int, (Ref{ZZZ},), a)
+end
+
+function (::Type{UInt})(a::ZZZ)
+    (a > typemax(UInt) || a < 0) && throw(InexactError(:convert, UInt, a))
+    return ccall((:fmpz_get_ui, libflint), UInt, (Ref{ZZZ},), a)
+end
+
+function (::Type{Float64})(n::ZZZ)
+    # rounds to zero
+    ccall((:fmpz_get_d, libflint), Float64, (Ref{ZZZ},), n)
+end
+
+(::Type{T})(a::ZZZ) where T<:Union{Int128,UInt128,BigFloat} = T(BigInt(a))
+
+(::Type{T})(a::ZZZ) where T<:Signed = T(Int(a))
+
+(::Type{T})(a::ZZZ) where T<:Unsigned = T(UInt(a))
+
+(::Type{T})(a::ZZZ) where T<:Union{Float16,Float32} = T(Float64(a))
+
+Base.convert(::Type{R}, z::ZZZ) where R<:Real = R(z)
+
+import Base: cmp, ==, <=, >=, <, >
+
+function cmp(x::ZZZ, y::ZZZ)
+    Int(ccall((:fmpz_cmp, libflint), Cint, (Ref{ZZZ}, Ref{ZZZ}), x, y))
+end
+
+function cmp(x::ZZZ, y::Int)
+    Int(ccall((:fmpz_cmp_si, libflint), Cint, (Ref{ZZZ}, Int), x, y))
+end
+
+function cmp(x::ZZZ, y::UInt)
+    Int(ccall((:fmpz_cmp_ui, libflint), Cint, (Ref{ZZZ}, UInt), x, y))
+end
+
+cmp(x::ZZZ, y::Integer) = cmp(value(x), y)
+
+cmp(x::Integer, y::ZZZ) = -cmp(y, x)
+
+for op in (:(==), :(!=), :(<=), :(>=), :(<), :(>))
+    @eval begin
+        $(op)(x::ZZZ, y::ZZZ) = $(op)(cmp(x, y), 0)
+        $(op)(x::ZZZ, y::Integer) = $(op)(cmp(x, y), 0)
+        $(op)(x::Integer, y::ZZZ) = $(op)(cmp(x, y), 0)
+    end
+end

--- a/src/zzmod.jl
+++ b/src/zzmod.jl
@@ -49,7 +49,7 @@ function promote_rule(ZT::Type{ZZmod{m,S}}, ZS::Type{ZZmod{n,T}}) where {n,m,T,S
     end
 end
 promote_rule(::Type{ZZmod{m,S}}, ::Type{T}) where {m,S,T<:Integer} = ZZmod{m,S}
-promote_rule(::Type{ZZmod{m,S}}, ::Type{T}) where {m,S,T<:ZZ} = ZZmod{m,S}
+promote_rule(::Type{ZZmod{m,S}}, ::Type{T}) where {m,S,T<:ZI} = ZZmod{m,S}
 
 function (::Type{ZT})(a::ZS) where {n,m,T,S,ZT<:ZZmod{n,T},ZS<:ZZmod{m,S}}
     mzt = modulus(ZT)

--- a/test/algebraic.jl
+++ b/test/algebraic.jl
@@ -131,10 +131,13 @@ end
     q = QQ(1 // 5)
     a = cispi(q)
     b = cospi(q)
+    c = sinpi(q)
+    d = tanpi(q)
     @test minimal_polynomial(a) == (x^5 + 1) / (x + 1)
     @test b == real(a)
-    @test sinpi(q) == imag(a)
-    @test cispi(-q) * cispi(q) == 1
+    @test c == imag(a)
+    @test cispi(-q) * a == 1
+    @test c / b == d
 end
 
 @testset "Algebraic - expressions" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,29 +1,36 @@
 using Test
 using CommutativeRings
 
-@testset "Aqua" begin include("Aqua.jl") end
+macro testsetif(args...)
+    isempty(ARGS) || in(args[end-1], ARGS) || return :nothing
+    quote
+        @testset($(args...))
+    end
+end
 
-@testset "typevars" begin include("typevars.jl") end
-@testset "generic" begin include("generic.jl") end
-@testset "ZZ" begin include("zz.jl") end
-@testset "QQ" begin include("qq.jl") end
-@testset "ZZmod" begin include("zzmod.jl") end
-@testset "galoisfields" begin include("galoisfields.jl") end
-@testset "fraction" begin include("fraction.jl") end
-@testset "quotient" begin include("quotient.jl") end
-@testset "univarpoly" begin include("univarpolynom.jl") end
-@testset "determinant" begin include("determinant.jl") end
-@testset "resultant" begin include("resultant.jl") end
-@testset "multivarpoly" begin include("multivarpolynom.jl") end
-@testset "ideal" begin include("ideal.jl") end
-@testset "factors" begin include("factorization.jl") end
-@testset "numbertheory" begin include("numbertheoretical.jl") end
-@testset "enumerations" begin include("enumerations.jl") end
-@testset "linearalgebra" begin include("linearalgebra.jl") end
-@testset "rationalnormal" begin include("rationalcanonical.jl") end
-@testset "intfactors" begin include("intfactorization.jl") end
-@testset "powerseries" begin include("powerseries.jl") end
-@testset "specialseries" begin include("specialseries.jl") end
-@testset "LLL" begin include("lll.jl") end
-@testset "fourier" begin include("fourier.jl") end
-@testset "fastMultiply" begin include("fastmultiply.jl") end
+@testsetif "Aqua" begin include("Aqua.jl") end
+
+@testsetif "typevars" begin include("typevars.jl") end
+@testsetif "generic" begin include("generic.jl") end
+@testsetif "ZZ" begin include("zz.jl") end
+@testsetif "QQ" begin include("qq.jl") end
+@testsetif "ZZmod" begin include("zzmod.jl") end
+@testsetif "galoisfields" begin include("galoisfields.jl") end
+@testsetif "fraction" begin include("fraction.jl") end
+@testsetif "quotient" begin include("quotient.jl") end
+@testsetif "univarpoly" begin include("univarpolynom.jl") end
+@testsetif "determinant" begin include("determinant.jl") end
+@testsetif "resultant" begin include("resultant.jl") end
+@testsetif "multivarpoly" begin include("multivarpolynom.jl") end
+@testsetif "ideal" begin include("ideal.jl") end
+@testsetif "factors" begin include("factorization.jl") end
+@testsetif "numbertheory" begin include("numbertheoretical.jl") end
+@testsetif "enumerations" begin include("enumerations.jl") end
+@testsetif "linearalgebra" begin include("linearalgebra.jl") end
+@testsetif "rationalnormal" begin include("rationalcanonical.jl") end
+@testsetif "intfactors" begin include("intfactorization.jl") end
+@testsetif "powerseries" begin include("powerseries.jl") end
+@testsetif "specialseries" begin include("specialseries.jl") end
+@testsetif "LLL" begin include("lll.jl") end
+@testsetif "fourier" begin include("fourier.jl") end
+@testsetif "fastMultiply" begin include("fastmultiply.jl") end


### PR DESCRIPTION
FLINT has the advantage, that it allows all integer values in a single type, maintaining performance for small values dynamically. The user has not to live with unnecessarily BigInt overhead or risk integer overflow.