### PR TITLE
Propagate FLINT for big integers 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ repo = "https://github.com/KlausC/CommutativeRings.jl"
 [deps]
 FLINT_jll = "e134572f-a0d5-539d-bddf-3cad8db41a82"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 

--- a/src/algebraic.jl
+++ b/src/algebraic.jl
@@ -124,6 +124,10 @@ end
 minimal_polynomial(a::AlgebraicNumber) = a.minpol
 approx(a::AlgebraicNumber) = a.approx
 deg(a::AlgebraicNumber) = deg(minimal_polynomial(a))
+function approx(a::AlgebraicNumber, id::Integer)
+    fap = a.roots[id]
+    closeroot(minimal_polynomial(a), big(fap), a.roots)
+end
 Base.zero(::Type{T}) where T<:AlgebraicNumber =
     T(UnivariatePolynomial{basetype(T),:x}([0, 1]), 0)
 Base.one(::Type{T}) where T<:AlgebraicNumber =
@@ -309,7 +313,7 @@ end
 fvalue(a::Number) = float(a)
 fvalue(a::Ring) = value(a)
 
-# find root of `p`, which is closest to `a`.
+# find root of `p`, which is closest to `a`, perform root iterations for full accuracy.
 function closeroot(p::UnivariatePolynomial, a::Number, r::AbstractVector{<:Number})
     p = primpart(p) # converts to ZZ[:x] - faster than QQ[:x]
 
@@ -698,3 +702,85 @@ field_matrix(a::AlgebraicNumber) = companion(minimal_polynomial(a))
 norm(a::AlgebraicNumber) = minimal_polynomial(a)[0] * (-1)^deg(a)
 tr(a::AlgebraicNumber) = -minimal_polynomial(a)[deg(a)-1]
 discriminant(a::AlgebraicNumber) = discriminant(minimal_polynomial(a))
+
+"""
+    Map a vector of indices, all ranging from 0:bounds[i]-1, to a linear index
+    based at 0
+"""
+function lindex(v::Vector{Int}, b::NTuple{N,<:Integer}) where N
+    n = length(v)
+    n <= N || throw(ArgumentError("index vector too long"))
+    li = v[n]
+    for i = n-1:-1:1
+        li = li * b[i] + v[i]
+    end
+    li
+end
+"""
+    Map a linear index to a vector of indices.
+"""
+function mindex(li::Integer, b::NTuple{N,<:Integer}) where N
+    v = Vector{Int}(undef, N)
+    for i = 1:N
+        li, v[i] = fldmod(li, b[i])
+    end
+    v
+end
+
+# generate a Matrix, which represents the A.N. with the canonical rational base.
+function matrixtower(A::AbstractVector{B}) where B<:AlgebraicNumber
+    n = length(A) - 1
+    if !isone(A[end])
+        A ./= A[end]
+    end
+    bounds = tuple(deg.(A)...)
+    N = prod(bounds)
+    M = zeros(ZZZ, N*n, N*n)
+    for k = 0:n-1
+        buildtower!(M, k, n, bounds, A)
+    end
+    for i=1:N*(n-1)
+        M[i+N, i] = 1
+    end
+    M
+end
+
+function buildtower!(M::AbstractMatrix, k::Integer, n::Integer, bounds::NTuple, A::AbstractVector)
+    N = prod(bounds)
+    a = minimal_polynomial(A[k+1])
+    for li = 0:N-1
+        di = N*k+1
+        dj = N*(n-1)+1
+        iv = mindex(li, bounds)
+        if iv[k+1] + 1 < bounds[k+1]
+            iv[k+1] += 1
+            lj = lindex(iv, bounds)
+            iv[k+1] -= 1
+            M[lj+di,li+dj] = -1
+        else
+            for j = 0:bounds[k+1]-1
+                iv[k+1] = j
+                lj = lindex(iv, bounds)
+                M[lj+di,li+dj] += a[j]
+            end
+            iv[k+1] = bounds[k+1] - 1
+        end
+    end
+    M
+end
+
+# constructive way of proving algebraic completeness of AlgebraicNumbers
+# Attention: the degree of the minimal polynomial explodes to the
+# product of the degrees of the defining A.N. and the degree of pa itself.
+function AlgebraicNumber(pa::UnivariatePolynomial{<:AlgebraicNumber})
+    AlgebraicNumber(pa[:])
+end
+
+import Polynomials
+
+function AlgebraicNumber(A::AbstractVector{<:AlgebraicNumber})
+    fapprox(a::AlgebraicNumber) = a.roots[a.rootid]
+    rpoly = Polynomials.Polynomial(fapprox.(A))
+    rr = Polynomials.roots(rpoly)[1]
+    AlgebraicNumber(characteristic_polynomial(matrixtower(A)), rr)
+end

--- a/src/algebraic.jl
+++ b/src/algebraic.jl
@@ -12,7 +12,9 @@ function AlgebraicNumber(
     a::Number = -Inf,
     ::Val = Val(:check),
 )
-    ps = [first(x) / LC(first(x)) for x in sff(p)]
+    iszero(denominator(p[0])) && deg(p) == 1 && return AlgebraicNumber(Inf)
+    isnan(a) && return AlgebraicNumber(NaN)
+    ps = [first(x) / LC(first(x)) for x in sff(p)] # squarefree and monic
     p, a, r, id = findbest(ps, a)
     AlgebraicNumber(p, r, id, a, NOCHECK)
 end
@@ -32,12 +34,13 @@ function AlgebraicNumber(a::Union{Integer,Rational{<:Integer},ZI,QQ})
     AlgebraicNumber(x - qa, [Float64(qa)], 1, qa, NOCHECK)
 end
 
-SMALL_INT = 999
+SMALL_INT = 1000
 function AlgebraicNumber(a::AbstractFloat)
+    isinteger(a) && return AlgebraicNumber(Integer(a))
     b = rationalize(a)
     bn = abs(numerator(b))
     bd = denominator(b)
-    if !(bn <= 1 || bd <= 1 || bn <= SMALL_INT && bd <= SMALL_INT)
+    if !(bn < SMALL_INT && bd < SMALL_INT)
         R = typeof(b)
         throw(InexactError(R.name.name, R, a))
     end
@@ -126,7 +129,7 @@ approx(a::AlgebraicNumber) = a.approx
 deg(a::AlgebraicNumber) = deg(minimal_polynomial(a))
 function approx(a::AlgebraicNumber, id::Integer)
     fap = a.roots[id]
-    closeroot(minimal_polynomial(a), big(fap), a.roots)
+    closeroot(minimal_polynomial(a), big(fap), a.roots)[1]
 end
 Base.zero(::Type{T}) where T<:AlgebraicNumber =
     T(UnivariatePolynomial{basetype(T),:x}([0, 1]), 0)
@@ -197,16 +200,23 @@ end
 
 sqrt(a::AlgebraicNumber) = ^(a, 1 // 2)
 # cbrt(a::AlgebraicNumber) = ^(a, 1 // 3) # intentionally not defined - alike Complex.
+isfinite(a::AlgebraicNumber) = isfinite(a.roots[a.rootid])
 isreal(a::AlgebraicNumber) = isreal(approx(a))
 real(a::AlgebraicNumber) = isreal(a) ? a : (a + conj(a)) / 2
 imag(a::AlgebraicNumber) = isreal(a) ? zero(a) : (conj(a) - a) * AlgebraicNumber(im) / 2
 abs(a::AlgebraicNumber) = !isreal(a) ? sqrt(a * conj(a)) : real(approx(a)) >= 0 ? a : -a
 
 function *(a::T, b::T) where T<:AlgebraicNumber
-    if a == b
+    if iszero(a)
+        isfinite(b) ? a : throw_D()
+    elseif iszero(b)
+        isfinite(a) ? b : throw_D()
+    elseif !isfinite(a)
+        !iszero(b) ? a : throw_D()
+    elseif !isfinite(b)
+        !iszero(a) ? b : throw_D()
+    elseif a == b
         literal_pow(^, a, Val(2))
-    elseif iszero(a) || iszero(b)
-        zero(T)
     else
         pab = multiply(a, b)
         AlgebraicNumber(pab, approx(a) * approx(b))
@@ -279,6 +289,8 @@ function lincomb(p::T, aa) where T<:UnivariatePolynomial
 end
 
 function inv(a::T) where T<:AlgebraicNumber
+    iszero(a) && return AlgebraicNumber(Inf)
+    isfinite(a) || return AlgebraicNumber(0)
     p = minimal_polynomial(a)
     q = reverse(p)
     q /= LC(q)
@@ -287,27 +299,31 @@ end
 
 # find best of irreducible factors with respect to having a root close to `a`.
 function findbest(ps::AbstractVector{<:UnivariatePolynomial}, a::Number)
-    p = bestpoly(ps, a)
-    if isreducible(p)
-        pss = [first(s) for s in factor(p)]
-        p = bestpoly(pss, a)
-    end
-    r = cr_roots(p)
-    b, id = closeroot(p, big(fvalue(a)), r)
-    p, b, r, id
-end
-
-function bestpoly(ps::AbstractVector{<:UnivariatePolynomial}, a::Number)
-    if length(ps) > 1
-        _, i = findmin(ps) do p
-            pa = abs(p(a))
-            dpa = abs(derive(p)(a))
-            dpa <= pa ? pa : pa / dpa
+    rmax = -1.0
+    res = []
+    for pp in ps
+        for p in [first(s) for s in factor(pp)]
+            r = cr_roots(p)
+            push!(res, (p, r))
+            rmax = max(rmax, maximum(abs, r))
         end
-    else
-        i = 1
     end
-    ps[i]
+    aa = fnormed(a, rmax)
+
+    bestd = Inf
+    bestp = first(ps)
+    bestr = ComplexF64[]
+    for (p, r) in res
+        _, b = nextroot(aa, r)
+        d = abs(b - aa)
+        if d < bestd
+            bestd = d
+            bestp = p
+            bestr = r
+        end
+    end
+    b, id = closeroot(bestp, big(fvalue(a)), bestr)
+    bestp, b, bestr, id
 end
 
 fvalue(a::Number) = float(a)
@@ -318,10 +334,11 @@ function closeroot(p::UnivariatePolynomial, a::Number, r::AbstractVector{<:Numbe
     p = primpart(p) # converts to ZZ[:x] - faster than QQ[:x]
 
     dp = derive(p)
+    a = fnormed(a, maximum(abs, r))
     id, a = nextroot(a, r)
     da = p(a) / dp(a)
     epsb = abs(a) * sqrt(eps(real(typeof(a))))
-    i = 10
+    i = 100
     while true
         a -= da
         i -= 1
@@ -336,7 +353,7 @@ struct NumericalError <: Exception
     text::AbstractString
 end
 
-function cr_roots(p::UnivariatePolynomial)
+function cr_roots(p::Union{<:UnivariatePolynomial,<:AbstractVector})
     A = companion(Float64, p)
     roots = LinearAlgebra.eigvals(A; permute = false, scale = false)
     map(roots) do x
@@ -345,27 +362,35 @@ function cr_roots(p::UnivariatePolynomial)
     end
 end
 
+"""
+    fnormed(a, b)
+
+If `abs(a)`is greater than
+ten times the `maximum(abs.(r))` its size is reduced to that value.
 fnormed(a::Real, b::Real) = abs(a) > b ? sign(a) * b : a
+"""
 function fnormed(a::C, b::Real) where {T,C<:Complex{T}}
     if isfinite(a)
         abs(a) > b ? sign(a) * b : a
     else
-        t = typemax(T)
-        sign(C(clamp.(reim(a)..., -t, t))) * b
+        t = floatmax(T) / sqrt(2)
+        re = clamp(real(a), -t, t)
+        ig = clamp(imag(a), -t, t)
+        sign(C(re, ig)) * b
     end
+end
+function fnormed(a::T, b::Real) where T<:Real
+    abs(a) > b ? sign(a) * b : a
 end
 
 """
     nextroot(a, r::Vector)
 
-Find the number in `r`, which is closest to `a`. If `abs(a)`is greater than
-ten times the `maximum(abs.(r))` its size is reduced to that value.
+Find the number in `r`, which is closest to `a`.
 """
 function nextroot(a::T, r::AbstractVector) where T<:Number
-    mx = 10.0 * maximum(abs, r)
-    b = fnormed(a, mx)
     _, i = findmin(r) do v
-        abs(b - v)
+        abs(a - v)
     end
     i, Complex{float(real(T))}(r[i])
 end
@@ -595,7 +620,7 @@ function isalgebraic(expr::Expr)
             isalgebraic(args[2]) || return false
             q = rationalconst(args[3])
             return !isnothing(q)
-        elseif fun ∉ (:(+), :(-), :(*), :(//), :inv, :sqrt, :cbrt)
+        elseif fun ∉ (:(+), :(-), :(*), :(//), :inv, :sqrtx, :cbrt)
             return false
         end
         n = length(args)
@@ -608,7 +633,22 @@ function isalgebraic(expr::Expr)
     end
 end
 
+replacesqrt!(s::Symbol) = s === :sqrt ? :sqrtx : s
+replacesqrt!(a::Any) = a
+function replacesqrt!(expr::Expr)
+    if expr.head == :call
+        args = expr.args
+        for i in axes(args, 1)
+            args[i] = replacesqrt!(args[i])
+        end
+    end
+    expr
+end
+
+sqrtx(x::Number) = sqrt(complex(x))
+
 function AlgebraicNumber(expr::Expr, pre::Union{Nothing,Number} = nothing)
+    replacesqrt!(expr)
     approx = pre === nothing ? eval(expr) : float(pre)
     A = AlgebraicNumber(to_algebraic_or_rational(expr))
     r = A.roots
@@ -630,7 +670,7 @@ function to_algebraic_or_rational(expr::Expr)
             q = rationalconst(args[3])
             denominator(q) != 1 && (a = AlgebraicNumber(a))
             return a^q
-        elseif fun ∈ (:(+), :(-), :(*), :(//), :(/), :inv, :sqrt, :cbrt)
+        elseif fun ∈ (:(+), :(-), :(*), :(//), :(/), :inv, :sqrtx, :cbrt)
             n = length(args)
             eargs = Vector{Any}(undef, n - 1)
             for j = 2:n
@@ -654,7 +694,7 @@ evaluate(::Val{:(*)}, args) = *(args...)
 evaluate(::Val{:(/)}, args) = /(args...)
 evaluate(::Val{:(//)}, args) = /(args...)
 evaluate(::Val{:(inv)}, args) = inv(args...)
-evaluate(::Val{:(sqrt)}, args) = sqrt(AlgebraicNumber(args[1]))
+evaluate(::Val{:(sqrtx)}, args) = sqrt(AlgebraicNumber(args[1]))
 evaluate(::Val{:(cbrt)}, args) = AlgebraicNumber(args[1])^(1 // 3)
 
 """
@@ -727,7 +767,7 @@ function mindex(li::Integer, b::NTuple{N,<:Integer}) where N
     v
 end
 
-# generate a Matrix, which represents the A.N. with the canonical rational base.
+# generate a Matrix, which represents the A.N. with the canonical base.
 function matrixtower(A::AbstractVector{B}) where B<:AlgebraicNumber
     n = length(A) - 1
     if !isone(A[end])
@@ -735,33 +775,39 @@ function matrixtower(A::AbstractVector{B}) where B<:AlgebraicNumber
     end
     bounds = tuple(deg.(A)...)
     N = prod(bounds)
-    M = zeros(ZZZ, N*n, N*n)
+    M = zeros(basetype(B), N * n, N * n)
     for k = 0:n-1
         buildtower!(M, k, n, bounds, A)
     end
-    for i=1:N*(n-1)
+    for i = 1:N*(n-1)
         M[i+N, i] = 1
     end
     M
 end
 
-function buildtower!(M::AbstractMatrix, k::Integer, n::Integer, bounds::NTuple, A::AbstractVector)
+function buildtower!(
+    M::AbstractMatrix,
+    k::Integer,
+    n::Integer,
+    bounds::NTuple,
+    A::AbstractVector,
+)
     N = prod(bounds)
     a = minimal_polynomial(A[k+1])
     for li = 0:N-1
-        di = N*k+1
-        dj = N*(n-1)+1
+        di = N * k + 1
+        dj = N * (n - 1) + 1
         iv = mindex(li, bounds)
         if iv[k+1] + 1 < bounds[k+1]
             iv[k+1] += 1
             lj = lindex(iv, bounds)
             iv[k+1] -= 1
-            M[lj+di,li+dj] = -1
+            M[lj+di, li+dj] = -1
         else
             for j = 0:bounds[k+1]-1
                 iv[k+1] = j
                 lj = lindex(iv, bounds)
-                M[lj+di,li+dj] += a[j]
+                M[lj+di, li+dj] += a[j]
             end
             iv[k+1] = bounds[k+1] - 1
         end
@@ -780,7 +826,6 @@ import Polynomials
 
 function AlgebraicNumber(A::AbstractVector{<:AlgebraicNumber})
     fapprox(a::AlgebraicNumber) = a.roots[a.rootid]
-    rpoly = Polynomials.Polynomial(fapprox.(A))
-    rr = Polynomials.roots(rpoly)[1]
+    rr = cr_roots(fapprox.(A))[1]
     AlgebraicNumber(characteristic_polynomial(matrixtower(A)), rr)
 end

--- a/src/algebraic.jl
+++ b/src/algebraic.jl
@@ -1,6 +1,7 @@
 
 import Base: *, /, inv, +, -, sqrt, ^, literal_pow, iszero, zero, one, ==, isapprox, hash
 import Base: conj, real, imag, abs, copy, isreal, cispi, cospi, sinpi, tanpi
+import Base.MathConstants: φ
 
 # construction
 basetype(::Type{<:AlgebraicNumber}) = QQ{ZZZ}
@@ -30,6 +31,18 @@ function AlgebraicNumber(a::Union{Integer,Rational{<:Integer},ZI,QQ})
     qa = Q(a)
     AlgebraicNumber(x - qa, [Float64(qa)], 1, qa, NOCHECK)
 end
+
+SMALL_INT = 999
+function AlgebraicNumber(a::AbstractFloat)
+    b = rationalize(a)
+    bn = abs(numerator(b))
+    bd = denominator(b)
+    if !(bn <= 1 || bd <= 1 || bn <= SMALL_INT && bd <= SMALL_INT)
+        R = typeof(b)
+        throw(InexactError(R.name.name, R, a))
+    end
+    AlgebraicNumber(b)
+end
 function AlgebraicNumber(a::Complex)
     if isreal(a)
         return AlgebraicNumber(real(a))
@@ -45,6 +58,23 @@ function AlgebraicNumber(a::Complex)
         ca = conj(ca)
     end
     AlgebraicNumber(x^2 - 2 * ra * x + ia^2 + ra^2, [ca, conj(ca)], id, a, NOCHECK)
+end
+function AlgebraicNumber(a::Complex{<:AbstractFloat})
+    r, i = reim(a)
+    if iszero(i)
+        AlgebraicNumber(r)
+    else
+        AlgebraicNumber(r) + AlgebraicNumber(i) * AlgebraicNumber(im)
+    end
+end
+function AlgebraicNumber(s::Symbol)
+    n = eval(s)
+    n in (im, Base.MathConstants.φ) || throw(ArgumentError("symbol `$s` not supported"))
+    AlgebraicNumber(n)
+end
+# note: `φ`` is typed `\varphi`
+function AlgebraicNumber(::typeof(Base.MathConstants.φ))
+    AlgebraicNumber(:((sqrt(5) + 1) / 2))
 end
 
 function AlgebraicNumber(p::UnivariatePolynomial, a = -Inf)
@@ -65,6 +95,7 @@ promote_rule(::Type{<:A}, ::Type{<:QQ}) where A<:AlgebraicNumber = A
 promote_rule(::Type{<:A}, ::Type{<:ZI}) where A<:AlgebraicNumber = A
 promote_rule(::Type{<:A}, ::Type{<:Integer}) where A<:AlgebraicNumber = A
 promote_rule(::Type{<:A}, ::Type{<:Rational}) where A<:AlgebraicNumber = A
+promote_rule(::Type{<:A}, ::Type{<:AbstractFloat}) where A<:AlgebraicNumber = A
 promote_rule(::Type{<:A}, ::Type{<:Complex}) where A<:AlgebraicNumber = A
 
 copy(a::AlgebraicNumber) = typeof(a)(minimal_polynomial(a), approx(a))
@@ -461,7 +492,6 @@ function _squaremulim(p::UnivariatePolynomial)
     c
 end
 
-
 """
     rationalconst(expr)
 
@@ -469,6 +499,7 @@ Return the value of a rational constant or a rational function of rational const
 if that can be expressed as `Rational`. Otherwise return `nothing`.
 """
 rationalconst(x::Integer) = big(x)
+rationalconst(x::AbstractFloat) = isinteger(x) ? Integer(x) : nothing
 rationalconst(::Any) = nothing
 
 function rationalconst(expr::Expr)
@@ -480,10 +511,15 @@ function rationalconst(expr::Expr)
         if fun == :(^)
             p = rationalconst(args[2])
             isnothing(p) && return p
-            q = rationalconst(args[3])
-            isnothing(q) && return q
-            denominator(q) != 1 && return nothing
-            return p^numerator(q)
+            e = rationalconst(args[3])
+            isnothing(e) && return e
+            en = numerator(e)
+            ed = denominator(e)
+            ed == 1 && return p^en
+            sn = Integer(trunc(numerator(p)^(1 / ed)))
+            sd = Integer(trunc(denominator(p)^(1 / ed)))
+            q = sn // sd
+            return q^ed == p ? q^en : nothing
         elseif fun == :inv
             p = rationalconst(args[2])
             isnothing(p) && return p
@@ -495,9 +531,16 @@ function rationalconst(expr::Expr)
             sd = isqrt(denominator(p))
             q = sn // sd
             return q^2 == p ? q : nothing
+        elseif fun == :cbrt
+            p = rationalconst(args[2])
+            isnothing(p) && return p
+            sn = Integer(trunc(cbrt(numerator(p))))
+            sd = Integer(trunc(cbrt(denominator(p))))
+            q = sn // sd
+            return q^3 == p ? q : nothing
         end
         if fun ∉ (:(+), :(-), :(*), :(//))
-            return false
+            return nothing
         end
         n = length(args)
         eargs = similar(args)
@@ -519,8 +562,12 @@ end
 Return true iff the expression describes an `AlgebraicNumber`.
 """
 
+const ALLOWED_SYMBOLS = (:im, :φ)
+
 isalgebraic(::AlgebraicNumber) = true
 isalgebraic(::Union{Rational,Integer}) = true
+isalgebraic(x::AbstractFloat) = isinteger(x)
+isalgebraic(s::Symbol) = s ∈ ALLOWED_SYMBOLS
 isalgebraic(::Any) = false
 
 function isalgebraic(expr::Expr)
@@ -533,7 +580,7 @@ function isalgebraic(expr::Expr)
             isalgebraic(args[2]) || return false
             q = rationalconst(args[3])
             return !isnothing(q)
-        elseif fun ∉ (:(+), :(-), :(*), :(//), :inv, :sqrt)
+        elseif fun ∉ (:(+), :(-), :(*), :(//), :inv, :sqrt, :cbrt)
             return false
         end
         n = length(args)
@@ -546,7 +593,14 @@ function isalgebraic(expr::Expr)
     end
 end
 
-AlgebraicNumber(expr::Expr) = AlgebraicNumber(to_algebraic_or_rational(expr))
+function AlgebraicNumber(expr::Expr, pre::Union{Nothing,Number} = nothing)
+    approx = pre === nothing ? eval(expr) : float(pre)
+    A = AlgebraicNumber(to_algebraic_or_rational(expr))
+    r = A.roots
+    p = A.minpol
+    a, id = closeroot(p, big(fvalue(approx)), r)
+    AlgebraicNumber(p, r, id, a, NOCHECK)
+end
 
 function to_algebraic_or_rational(expr::Expr)
     x = rationalconst(expr)
@@ -561,7 +615,7 @@ function to_algebraic_or_rational(expr::Expr)
             q = rationalconst(args[3])
             denominator(q) != 1 && (a = AlgebraicNumber(a))
             return a^q
-        elseif fun ∈ (:(+), :(-), :(*), :(//), :(/), :inv, :sqrt)
+        elseif fun ∈ (:(+), :(-), :(*), :(//), :(/), :inv, :sqrt, :cbrt)
             n = length(args)
             eargs = Vector{Any}(undef, n - 1)
             for j = 2:n
@@ -574,7 +628,10 @@ function to_algebraic_or_rational(expr::Expr)
         throw(ArgumentError("no call, but $head"))
     end
 end
-to_algebraic_or_rational(a::Integer) = a
+to_algebraic_or_rational(a::Number) = a
+function to_algebraic_or_rational(s::Symbol)
+    s in ALLOWED_SYMBOLS ? AlgebraicNumber(s) : throw(ArgumentError("unexpected symbol $s"))
+end
 
 evaluate(::Val{:(+)}, args) = +(args...)
 evaluate(::Val{:(-)}, args) = -(args...)
@@ -583,6 +640,7 @@ evaluate(::Val{:(/)}, args) = /(args...)
 evaluate(::Val{:(//)}, args) = /(args...)
 evaluate(::Val{:(inv)}, args) = inv(args...)
 evaluate(::Val{:(sqrt)}, args) = sqrt(AlgebraicNumber(args[1]))
+evaluate(::Val{:(cbrt)}, args) = AlgebraicNumber(args[1])^(1 // 3)
 
 """
     com2(p, q)

--- a/src/algebraic.jl
+++ b/src/algebraic.jl
@@ -306,7 +306,6 @@ function bestpoly(ps::AbstractVector{<:UnivariatePolynomial}, a::Number)
     ps[i]
 end
 
-
 fvalue(a::Number) = float(a)
 fvalue(a::Ring) = value(a)
 
@@ -318,8 +317,8 @@ function closeroot(p::UnivariatePolynomial, a::Number, r::AbstractVector{<:Numbe
     id, a = nextroot(a, r)
     da = p(a) / dp(a)
     epsb = abs(a) * sqrt(eps(real(typeof(a))))
-    i = 100
-    for _ = 1:i
+    i = 10
+    while true
         a -= da
         i -= 1
         i = abs(da) < epsb ? min(1, i) : i
@@ -342,17 +341,29 @@ function cr_roots(p::UnivariatePolynomial)
     end
 end
 
-function nextroot(a, r::AbstractVector)
-    _, i = findmin(r) do v
-        if isfinite(a)
-            abs(a - v)
-        elseif a == Inf
-            -real(v)
-        else
-            real(v)
-        end
+fnormed(a::Real, b::Real) = abs(a) > b ? sign(a) * b : a
+function fnormed(a::C, b::Real) where {T,C<:Complex{T}}
+    if isfinite(a)
+        abs(a) > b ? sign(a) * b : a
+    else
+        t = typemax(T)
+        sign(C(clamp.(reim(a)..., -t, t))) * b
     end
-    i, Complex{float(real(typeof(a)))}(r[i]), r
+end
+
+"""
+    nextroot(a, r::Vector)
+
+Find the number in `r`, which is closest to `a`. If `abs(a)`is greater than
+ten times the `maximum(abs.(r))` its size is reduced to that value.
+"""
+function nextroot(a::T, r::AbstractVector) where T<:Number
+    mx = 10.0 * maximum(abs, r)
+    b = fnormed(a, mx)
+    _, i = findmin(r) do v
+        abs(b - v)
+    end
+    i, Complex{float(real(T))}(r[i])
 end
 
 function Base.conj(a::AlgebraicNumber)

--- a/src/algebraic.jl
+++ b/src/algebraic.jl
@@ -3,7 +3,7 @@ import Base: *, /, inv, +, -, sqrt, ^, literal_pow, iszero, zero, one, ==, isapp
 import Base: conj, real, imag, abs, copy, isreal, cispi, cospi, sinpi, tanpi
 
 # construction
-basetype(::Type{<:AlgebraicNumber}) = QQ{BigInt}
+basetype(::Type{<:AlgebraicNumber}) = QQ{ZZZ}
 category_trait(::Type{A}) where A<:AlgebraicNumber = category_trait(basetype(A))
 
 function AlgebraicNumber(
@@ -21,10 +21,10 @@ function AlgebraicNumber(
     ::Val{:irreducible},
 )
     r = cr_roots(p)
-    a, id = closeroot(p, big(value(a)), r)
+    a, id = closeroot(p, big(fvalue(a)), r)
     AlgebraicNumber(p, r, id, a, NOCHECK)
 end
-function AlgebraicNumber(a::Union{Integer,Rational{<:Integer},ZZ,QQ})
+function AlgebraicNumber(a::Union{Integer,Rational{<:Integer},ZI,QQ})
     Q = basetype(AlgebraicNumber)
     x = monom(Q[:x])
     qa = Q(a)
@@ -62,7 +62,7 @@ Base.convert(::Type{T}, a::Ring) where T<:AlgebraicNumber = T(a)
 Base.convert(::Type{T}, a::AlgebraicNumber) where T<:AlgebraicNumber = a
 
 promote_rule(::Type{<:A}, ::Type{<:QQ}) where A<:AlgebraicNumber = A
-promote_rule(::Type{<:A}, ::Type{<:ZZ}) where A<:AlgebraicNumber = A
+promote_rule(::Type{<:A}, ::Type{<:ZI}) where A<:AlgebraicNumber = A
 promote_rule(::Type{<:A}, ::Type{<:Integer}) where A<:AlgebraicNumber = A
 promote_rule(::Type{<:A}, ::Type{<:Rational}) where A<:AlgebraicNumber = A
 promote_rule(::Type{<:A}, ::Type{<:Complex}) where A<:AlgebraicNumber = A
@@ -101,9 +101,9 @@ Base.iszero(a::AlgebraicNumber) = deg(a) == 1 && minimal_polynomial(a).first == 
 isone(a::AlgebraicNumber) = deg(a) == 1 && isone(-minimal_polynomial(a)[0])
 isunit(a::AlgebraicNumber) = !iszero(a)
 
-approx(a::Union{Integer,Rational,ZZ,QQ}) = float(value(a))
+approx(a::Union{Integer,Rational,ZI,QQ}) = float(fvalue(a))
 
-function literal_pow(::typeof(^), a::AlgebraicNumber, ::Val{2})
+@inline function literal_pow(::typeof(^), a::AlgebraicNumber, ::Val{2})
     p = minimal_polynomial(a)
     x = monom(typeof(p))
     q = compress(p(-x) * p, 2)
@@ -112,10 +112,10 @@ function literal_pow(::typeof(^), a::AlgebraicNumber, ::Val{2})
     end
     AlgebraicNumber(q, approx(a)^2)
 end
-literal_pow(::typeof(^), a::AlgebraicNumber, ::Val{1}) = a
-literal_pow(::typeof(^), a::AlgebraicNumber, ::Val{3}) = pow(a, 3)
-literal_pow(::typeof(^), a::AlgebraicNumber, ::Val{-1}) = inv(a)
-literal_pow(::typeof(^), a::AlgebraicNumber, ::Val{-2}) = inv(a^2)
+@inline literal_pow(::typeof(^), a::AlgebraicNumber, ::Val{1}) = a
+@inline literal_pow(::typeof(^), a::AlgebraicNumber, ::Val{3}) = pow(a, 3)
+@inline literal_pow(::typeof(^), a::AlgebraicNumber, ::Val{-1}) = inv(a)
+@inline literal_pow(::typeof(^), a::AlgebraicNumber, ::Val{-2}) = inv(a^2)
 
 ^(a::AlgebraicNumber, n::Integer) = pow(a, n)
 function ^(a::AlgebraicNumber, q::Rational{<:Integer})
@@ -179,7 +179,7 @@ function *(a::T, b::T) where T<:AlgebraicNumber
 end
 
 *(a::T, aa::RingNumber) where T<:AlgebraicNumber =
-    AlgebraicNumber(lincomb(minimal_polynomial(a), aa), approx(a) * value(aa))
+    AlgebraicNumber(lincomb(minimal_polynomial(a), aa), approx(a) * fvalue(aa))
 *(aa::RingNumber, a::T) where T<:AlgebraicNumber = a * aa
 *(p::P, a::R) where {R<:AlgebraicNumber,P<:UnivariatePolynomial{R}} = P(coeffs(p) .* a)
 *(a::R, p::P) where {R<:AlgebraicNumber,P<:UnivariatePolynomial{R}} = P(coeffs(p) .* a)
@@ -258,7 +258,7 @@ function findbest(ps::AbstractVector{<:UnivariatePolynomial}, a::Number)
         p = bestpoly(pss, a)
     end
     r = cr_roots(p)
-    b, id = closeroot(p, big(value(a)), r)
+    b, id = closeroot(p, big(fvalue(a)), r)
     p, b, r, id
 end
 
@@ -276,7 +276,8 @@ function bestpoly(ps::AbstractVector{<:UnivariatePolynomial}, a::Number)
 end
 
 
-value(a::Number) = float(a)
+fvalue(a::Number) = float(a)
+fvalue(a::Ring) = value(a)
 
 # find root of `p`, which is closest to `a`.
 function closeroot(p::UnivariatePolynomial, a::Number, r::AbstractVector{<:Number})
@@ -393,7 +394,7 @@ end
 
 Return the algebraic number at `exp(pi * r * im)`.
 """
-Base.cispi(q::Q) where Q<:QQ = _cispi(Q, value(q))
+Base.cispi(q::Q) where Q<:QQ = _cispi(Q, fvalue(q))
 function _cispi(Q::Type{<:QQ}, r::Rational{<:Integer})
     r = mod(r + 1, 2) - 1
     r //= 2
@@ -412,7 +413,7 @@ function Base.sincospi(q::QQ)
     b = inv(e)
     c = (a + b) / 2
     s = ((a - b) / 2)^2
-    fs, fc = sincospi(big(value(q)))
+    fs, fc = sincospi(big(fvalue(q)))
     as = sqrt(AlgebraicNumber(-s, fs^2))
     ac = AlgebraicNumber(c, fc)
     as, ac
@@ -423,7 +424,7 @@ function Base.sinpi(q::QQ)
     a = monom(N)
     b = inv(a)
     s = (a - b) / 2
-    fs = sinpi(big(value(q))) * im
+    fs = sinpi(big(fvalue(q))) * im
     as = AlgebraicNumber(s, fs)
     AlgebraicNumber(_squaremulim(minimal_polynomial(as)), approx(as) / im)
 end
@@ -433,7 +434,7 @@ function Base.cospi(q::QQ)
     a = monom(N)
     b = inv(a)
     c = (a + b) / 2
-    fc = cospi(big(value(q)))
+    fc = cospi(big(fvalue(q)))
     ac = AlgebraicNumber(c, fc)
     ac
 end
@@ -443,7 +444,7 @@ function Base.tanpi(q::QQ)
     a = monom(N)
     b = inv(a)
     c = (a - b) / (a + b)
-    fc = tanpi(big(value(q))) * im
+    fc = tanpi(big(fvalue(q))) * im
     ac = AlgebraicNumber(c, fc)
     AlgebraicNumber(_squaremulim(minimal_polynomial(ac)), approx(ac) / im)
 end
@@ -594,7 +595,7 @@ Is an alternative to `det(x - companion(p, q))` which is faster sometimes.
 """
 function com2(p::UnivariatePolynomial{T}, q) where T
     n = deg(p)
-    S = typeof(value(p[0]))
+    S = typeof(fvalue(p[0]))
     M = zeros(S, n, n)
     s = q^0
     for i = 0:n-1

--- a/src/enumerations.jl
+++ b/src/enumerations.jl
@@ -156,7 +156,7 @@ len(T::Type{<:GaloisField}) = order(T)
 ofindex(a::Integer, u::Type{Union{}}) = throw(MethodError(ofindex, (a, u)))
 ofindex(a::Integer, T::Type{<:Unsigned}) = T(a)
 ofindex(a::Integer, T::Type{<:Signed}) = iseven(a) ? -(T(a) >> 1) : T(a + 1) >> 1
-ofindex(a::Integer, T::Type{ZZ{S}}) where S = T(ofindex(a, S))
+ofindex(a::Integer, T::Type{<:ZI}) = T(ofindex(a, basetype(T)))
 ofindex(a::Integer, T::Type{<:ZZmod{m,S}}) where {m,S} = T(ofindex(a, unsigned(S)))
 function ofindex(a::Integer, T::Type{<:QuotientRing{S}}) where {S<:UnivariatePolynomial}
     d = deg(modulus(T))

--- a/src/fraction.jl
+++ b/src/fraction.jl
@@ -2,7 +2,7 @@
 # class constructors
 Frac(a::Type{Union{}}, s...) = merror(irreducible, (a, s...))
 Frac(::Type{R}) where R<:Ring = Frac{R}
-Frac(::Type{<:ZZ{R}}) where R<:Integer = QQ{R}
+Frac(::Type{T}) where T<:ZI = QQ{basetype(T)}
 Frac(::Type{R}) where R<:Integer = QQ{R}
 
 # construction
@@ -49,8 +49,8 @@ Frac{T}(a::Integer) where T = Frac{T}(T(a), one(T), NOCHECK)
 Frac{T}(a::Rational{<:Integer}) where T = Frac{T}(T(a.num), T(a.den), NOCHECK)
 Frac{T}(a::Ring) where T = Frac{T}(T(a), one(T), NOCHECK)
 Frac(a::T) where T<:Ring = Frac{T}(a)
-Frac(a::T) where T<:Integer = Frac{ZZ{T}}(a)
-Frac(a::Rational{T}) where T<:Integer = Frac(ZZ{T})(a)
+Frac(a::T) where T<:Integer = Frac{ZZZ}(a)
+Frac(a::Rational{T}) where T<:Integer = Frac(ZZZ)(a)
 Frac{T}(a::Integer, b::Integer) where T = Frac(T(a), T(b))
 function Frac(a::T, b::T) where T<:UnivariatePolynomial
     sh = ord(a) - ord(b)
@@ -104,7 +104,7 @@ Frac{T}(a, b) where T = Frac(T(a), T(b))
 promote_rule(::Type{Frac{T}}, ::Type{Frac{S}}) where {S,T} = Frac{promote_type(S, T)}
 function promote_rule(::Type{Frac{T}}, ::Type{S}) where {S<:Ring,T}
     R = promote_type(S, T)
-    R <: Union{Polynomial, ZZ} ? Frac{R} : R
+    R <: Union{Polynomial, ZI} ? Frac{R} : R
 end
 promote_rule(::Type{Frac{T}}, ::Type{S}) where {S<:Integer,T} = Frac{promote_type(S, T)}
 promote_rule(::Type{Frac{T}}, ::Type{Rational{S}}) where {S<:Integer,T} =
@@ -167,7 +167,7 @@ evaluate(p::Frac, a) = fracdiv(evaluate(p.num, a), evaluate(p.den, a))
 fracdiv(a, b) = fracdiv(promote(a, b)...)
 fracdiv(a::T, b::T) where T = a * inv(b)
 fracdiv(a::T, b::T) where T<:Integer = a // b
-fracdiv(a::T, b::T) where T<:ZZ = a // b
+fracdiv(a::T, b::T) where T<:ZI = a // b
 fracdiv(a::T, b::T) where T<:OtherFloat = a / b
 
 derive(p::Frac) = (derive(p.num) * p.den - p.num * derive(p.den)) // p.den // p.den
@@ -286,7 +286,7 @@ function enparen(s::String)
 end
 
 # conversions from fractions
-(::Type{S})(a::T) where {S<:Union{Integer,ZZ},T<:Union{QQ,Frac}} = fractless(S, a)
+(::Type{S})(a::T) where {S<:Union{Integer,ZI},T<:Union{QQ,Frac}} = fractless(S, a)
 (::Type{S})(a::Frac{T}) where {S<:UnivariatePolynomial,T<:Polynomial} = fractless(S, a)
 UnivariatePolynomial(a::Frac{T}) where {T<:Polynomial} = fractless(UnivariatePolynomial, a)
 

--- a/src/galoisfields.jl
+++ b/src/galoisfields.jl
@@ -46,7 +46,7 @@ function _GF(p::Integer, r::Integer, mod, nr::Integer, maxord::Int)
     fact = Primes.factor(mm)
     Q = GFImpl(p, r, fact; nr, mod)
     r == 1 && mod === nothing && return Q
-    ord = order(p, r)
+    ord = order(Q)
     q = dimension(subfield(Q))
     r = dimension(Q) * q
     T = mintype_for(p, r, true)
@@ -54,7 +54,11 @@ function _GF(p::Integer, r::Integer, mod, nr::Integer, maxord::Int)
 
     gen = monom(Q)
     while order(gen) != ord - 1
-        gen, = next(gen)
+        nx = next(gen)
+        if nx === nothing
+            terror("no generator with maximal order found")
+        end
+        gen, = nx
     end
     g = tonumber(gen, pq)
 

--- a/src/galoisfields.jl
+++ b/src/galoisfields.jl
@@ -27,7 +27,7 @@ If `nr != 0` is given, in the case of modulus calculation, the first `nr` soluti
 `maxord` defines the maximal order, for which logarithm tables are stored to implement the class.
 Otherwise a representation by quotient space of the polynomial over `ZZ/p` is used.
 """
-function GF(n::Integer, k::Integer = 1; mod = :conway, nr = 0, maxord = 2^20)
+function GF(n::Integer, k::Integer=1; mod=:conway, nr=0, maxord=2^20)
     f = Primes.factor(n)
     length(f) == 1 || terror("$n is not p^r with p prime and r >= 1")
     p, r = f.pe[1]
@@ -153,12 +153,9 @@ basetype(::Type{GaloisField{C,D,Id,T,Q}}) where {C,D,Id,T,Q} = Q
 characteristic(G::Type{<:GaloisField}) = characteristic(basetype(G))
 characteristic(a::Type{Union{}}) = merror(characteristic, (a,))
 dimension(G::Type{<:GaloisField}) = dimension(basetype(G)) * dimension(subfield(G))
-@generated function order(a::Type{<:GaloisField})
-    function order(::Type{<:Type{<:GaloisField{C,D}}}) where {C,D}
-        ord = intpower(C, D)
-        convert(promote_type(typeof(ord), Int), ord)
-    end
-    order(a)
+function order(::Type{<:GaloisField{C,D}}) where {C,D}
+    ord = intpower(C, D)
+    convert(promote_type(typeof(ord), Int), ord)
 end
 lognegone(G::Type{<:GaloisField}) = characteristic(G) == 2 ? 0 : (order(G) - 1) ÷ 2
 modulus(G::Type{<:GaloisField}) = modulus(basetype(G))
@@ -448,14 +445,14 @@ are not negative and `p` is not less than the maximum of those coeffs.
 If `a` is `GaloisField` element, p defaults to the order of the subfield, which is used
 to represent the field.
 """
-function tonumber(u::UnivariatePolynomial, p::Integer = order(basetype(typeof(u))))
+function tonumber(u::UnivariatePolynomial, p::Integer=order(basetype(typeof(u))))
     s = zero(intpower(p, deg(u) + 1))
     for c in reverse(u.coeff)
         s = s * p + tonumber(c)
     end
     s * intpower(p, ord(u))
 end
-function tonumber(a::Q, p::Integer = order(subfield(Q))) where Q<:Quotient
+function tonumber(a::Q, p::Integer=order(subfield(Q))) where Q<:Quotient
     tonumber(value(a), p)
 end
 function tonumber(g::G) where G<:GaloisField
@@ -504,10 +501,10 @@ Elements of the field can be created like
 """
 function GFImpl(
     p::Integer,
-    m::Integer = 1,
-    factors = nothing;
-    nr::Integer = 0,
-    mod = :conway,
+    m::Integer=1,
+    factors=nothing;
+    nr::Integer=0,
+    mod=:conway,
 )
     isprime(p) || terror("base $p must be prime")
     m > 0 || terror("exponent m=$m must be positive")
@@ -567,7 +564,7 @@ function gf(a::String, b::Integer)
     r = max(r, r1)
     G = GF(p, r)
     tp(x) = isempty(x) ? 0 : tryparse(Int, x)
-    v = mapfoldl(tp, (a, b) -> a * p + b, digs; init = 0)
+    v = mapfoldl(tp, (a, b) -> a * p + b, digs; init=0)
     ofindex(v, G)
 end
 
@@ -607,7 +604,7 @@ base of `Q` as a vector space over `ZZ/p` (a normal base).
 """
 function normalmatrix(
     a::Q,
-    m::Integer = 0,
+    m::Integer=0,
 ) where {Z<:ZZmod,P<:UnivariatePolynomial{Z},Q<:Quotient{P}}
     p = characteristic(Q)
     r = dimension(Q)
@@ -630,7 +627,7 @@ Return `normalmatrix(a, m)` for the first `a` in `Q` for which this has maximal 
 """
 function normalmatrix(
     ::Type{Q},
-    m::Integer = 0,
+    m::Integer=0,
 ) where {Z<:ZZmod,P<:UnivariatePolynomial{Z},Q<:Quotient{P}}
     normalmatrix(normalbase(Q), m)
 end
@@ -680,7 +677,7 @@ function *(
     mulsized(M, a.val)
 end
 
-function monom(::Type{Q}, k::Integer, lc = 1) where {P<:UnivariatePolynomial,Q<:Quotient{P}}
+function monom(::Type{Q}, k::Integer, lc=1) where {P<:UnivariatePolynomial,Q<:Quotient{P}}
     k < dimension(Q) ? Q(monom(P, k, lc)) : lc == 1 ? Q(monom(P))^k : Q(monom(P))^k * lc
 end
 
@@ -703,7 +700,7 @@ end
 function homomorphism(
     ::Type{R},
     ::Type{S},
-    nr::Integer = 0,
+    nr::Integer=0,
 ) where {T<:Union{Quotient{<:UnivariatePolynomial{<:ZZmod}},GaloisField},R<:T,S<:T}
 
     r = dimension(R)
@@ -772,7 +769,7 @@ function _homomorphism(
     1, 1
 end
 
-function homomorphism(iso::Function, nr::Integer = 0)
+function homomorphism(iso::Function, nr::Integer=0)
     N = iso.A.N
     M1 = iso.A.M1
     Q = iso.A.Q
@@ -780,7 +777,7 @@ function homomorphism(iso::Function, nr::Integer = 0)
     _homomorphism(Q, R, N, M1, nr)
 end
 
-function homomorphism(::Type{Z}, ::Type{H}, nr::Integer = 0) where {Z<:ZZmod,H<:GaloisField}
+function homomorphism(::Type{Z}, ::Type{H}, nr::Integer=0) where {Z<:ZZmod,H<:GaloisField}
     characteristic(Z) == characteristic(H) || terror("different characteristics")
     Hom{Z,H}(x -> H(x))
 end
@@ -788,7 +785,7 @@ end
 function homomorphism2(
     ::Type{G},
     ::Type{H},
-    nr::Integer = 0,
+    nr::Integer=0,
 ) where {G<:GaloisField,H<:GaloisField}
     N, M1 = _homomorphism(basetype(G), basetype(H))
     Hom{G,H}(_homomorphism(G, H, N, M1, nr))
@@ -797,7 +794,7 @@ end
 function homomorphism2(
     ::Type{Q},
     ::Type{R},
-    nr::Integer = 0,
+    nr::Integer=0,
 ) where {Z<:ZZmod,P<:UnivariatePolynomial{Z},Q,R<:Quotient{P}}
     N, M1 = _homomorphism(Q, R)
     _homomorphism(Q, R, N, M1, nr)
@@ -810,7 +807,7 @@ function _homomorphism(::Type{Q}, ::Type{R}, N, M1, nr::Integer) where {Q,R}
     if nr != 0
         N = hcat(N[:, nr+1:r], N[:, 1:nr])
     end
-    A = (T = N * M1, N = N, M1 = M1, Q = Q, R = R)
+    A = (T=N * M1, N=N, M1=M1, Q=Q, R=R)
     quot(x) = x
     quot(x::GaloisField) = Quotient(x)
     iso(a::Q) = R(A.T * quot(a))

--- a/src/galoisfields.jl
+++ b/src/galoisfields.jl
@@ -46,7 +46,7 @@ function _GF(p::Integer, r::Integer, mod, nr::Integer, maxord::Int)
     fact = Primes.factor(mm)
     Q = GFImpl(p, r, fact; nr, mod)
     r == 1 && mod === nothing && return Q
-    ord = order(Q)
+    ord = order(p, r)
     q = dimension(subfield(Q))
     r = dimension(Q) * q
     T = mintype_for(p, r, true)
@@ -153,8 +153,9 @@ basetype(::Type{GaloisField{C,D,Id,T,Q}}) where {C,D,Id,T,Q} = Q
 characteristic(G::Type{<:GaloisField}) = characteristic(basetype(G))
 characteristic(a::Type{Union{}}) = merror(characteristic, (a,))
 dimension(G::Type{<:GaloisField}) = dimension(basetype(G)) * dimension(subfield(G))
-function order(::Type{<:GaloisField{C,D}}) where {C,D}
-    ord = intpower(C, D)
+order(::Type{<:GaloisField{C,D}}) where {C,D} = order(C, D)
+function order(c::Integer, d::Integer)
+    ord = intpower(c, d)
     convert(promote_type(typeof(ord), Int), ord)
 end
 lognegone(G::Type{<:GaloisField}) = characteristic(G) == 2 ? 0 : (order(G) - 1) ÷ 2

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -28,8 +28,8 @@ for op in (
 end
 for op in (:+, :-, :*, :/, :\, :isapprox)
     @eval begin
-        ($op)(a::Union{QQ,ZI}, b::OtherNumber) = ($op)(promote(a, b)...)
-        ($op)(a::OtherNumber, b::Union{QQ,ZI}) = ($op)(promote(a, b)...)
+        ($op)(a::Union{QQ,ZI,AlgebraicNumber}, b::OtherNumber) = ($op)(promote(a, b)...)
+        ($op)(a::OtherNumber, b::Union{QQ,ZI,AlgebraicNumber}) = ($op)(promote(a, b)...)
     end
 end
 

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -28,8 +28,8 @@ for op in (
 end
 for op in (:+, :-, :*, :/, :\, :isapprox)
     @eval begin
-        ($op)(a::Union{QQ,ZZ}, b::OtherNumber) = ($op)(promote(a, b)...)
-        ($op)(a::OtherNumber, b::Union{QQ,ZZ}) = ($op)(promote(a, b)...)
+        ($op)(a::Union{QQ,ZI}, b::OtherNumber) = ($op)(promote(a, b)...)
+        ($op)(a::OtherNumber, b::Union{QQ,ZI}) = ($op)(promote(a, b)...)
     end
 end
 
@@ -43,7 +43,7 @@ Base.iterate(::Ring, ::Any) = nothing
 Base.isempty(::Ring) = false
 Base.in(a::Ring, b::Ring) = a == b
 Base.map(f, a::Ring, bs::Ring...) = f(a, bs...)
-Base.big(a::T) where T<:Union{QQ,ZZ} = big(T)(a)
+Base.big(a::T) where T<:Union{QQ,ZI} = big(T)(a)
 
 basetype(::T) where T<:Ring = basetype(T)
 basetype(::Type{T}) where T = Union{}
@@ -74,14 +74,22 @@ generatorset(::Type{P}) where P<:Quotient{<:Polynomial} = generatorset(basetype(
 
 adjoint(a::Ring) = a
 
-@generated function basetypes(a::DataType)
-    _basetypes(::Type{Union{}}) = DataType[]
-    _basetypes(::Type{a}) where a = begin
-        b = basetype(a)
-        [a; _basetypes(b)]
+function _basetypes(a::Type)
+    res = DataType[]
+    b = a
+    while b !== Union{}
+        push!(res, b)
+        b = basetype(b)
     end
-    bt = tuple(_basetypes(a.parameters[1])...)
-    :($bt)
+    tuple(res...)
+end
+
+const BASE_TYPES = IdDict{UInt,Tuple}()
+basetypes(::Type) = ()
+function basetypes(a::DataType)
+    get!(BASE_TYPES, objectid(a)) do
+        _basetypes(a)
+    end
 end
 
 function /(a::T, b::T) where T<:Ring
@@ -582,7 +590,7 @@ end
 
 category_trait(a::Type{Union{}}) = throw(MethodError(category_trait, (a,)))
 
-@noinline terror(s...) =  throw(ArgumentError(string(s...)))
+@noinline terror(s...) = throw(ArgumentError(string(s...)))
 @noinline merror(f, s...) = throw(MethodError(f, tuple(s...)))
 @noinline merror(f, s::Tuple) = throw(MethodError(f, s))
 

--- a/src/ideal.jl
+++ b/src/ideal.jl
@@ -14,7 +14,7 @@ function Ideal(m::R) where R<:Ring
         Ideal{R}([m])
     end
 end
-Ideal(m::T) where T<:Integer = Ideal(ZZ{T}(m))
+Ideal(m::T) where T<:Integer = Ideal(ZZZ(m))
 Ideal(mm::RingInt...) = Ideal(collect(Base.promote_typeof(mm...), mm))
 Ideal(mm::AbstractVector{<:RingInt}) = Ideal(gcd(mm))
 Ideal(mm::AbstractVector{R}) where R<:MultivariatePolynomial = Ideal{R}(groebnerbase(mm))
@@ -38,8 +38,8 @@ function issubset(id1::Ideal{R}, id2::Ideal{R}) where R<:Polynomial
 end
 
 ==(id1::Ideal{R}, id2::Ideal{S}) where {R<:Ring,S<:Ring} = id1.base == id2.base
-==(id::Ideal{R}, ::Type{R}) where R<:Ring = isone(id)
-==(::Type{R}, id::Ideal{R}) where R<:Ring = isone(id)
+==(id::Ideal{R}, ::Type{S}) where {R,S<:Ring} = isone(id) && (R == S || S<:ZZ && R<:ZZZ)
+==(::Type{S}, id::Ideal{R}) where {R,S<:Ring} = id == S
 
 function +(id1::Ideal{R}, id2::Ideal{R}) where R<:MultivariatePolynomial
     Ideal(vcat(id1.base, id2.base))

--- a/src/intfactorization.jl
+++ b/src/intfactorization.jl
@@ -101,7 +101,7 @@ function yun(u::P) where P<:UnivariatePolynomial
 end
 
 function yun(u::P) where P<:UnivariatePolynomial{<:QQ}
-    c, q = content_primpart(u) # q is ZZ!
+    c, q = content_primpart(u) # q is ZZ or ZZZ!
     y = yun(q)
     c *= LC(q)
     z = [P(y[1])*c; [P(y[i])/LC(y[i]) for i in 2:length(y)]]
@@ -141,8 +141,8 @@ function zassenhaus(u; p0)
     zassenhaus2(u, Val(false), p0)
 end
 
-function zassenhaus2(u::UnivariatePolynomial{<:ZZ{<:Integer}}, val::Val{BO}, p0) where BO
-    Z = ZZ{BigInt}[varname(u)]
+function zassenhaus2(u::UnivariatePolynomial{B}, val::Val{BO}, p0) where {BO,B<:ZI}
+    Z = big(B)[varname(u)]
     u = convert(Z, u)
     zassenhaus2(u, val, p0)
 end
@@ -244,7 +244,7 @@ end
 """
     factor(u::UnivariatePolynomial, a::Integer; p0 = MINPRIME)
 
-factorize polynomial `u(x^a)` over `ZZ`.
+factorize polynomial `u(x^a)` over `ZZZ`.
 """
 function factor_exp(u::P, a::Integer, p0) where P<:UnivariatePolynomial
     #println("factor1($u, $a)")
@@ -627,7 +627,7 @@ function remove_subset!(vv::AbstractVector, d)
 end
 
 """
-    smallfactors(vv::Vector{Polynomial{ZZ/p}}, u::Polynomial{ZZ{Integer}})::w
+    smallfactors(vv::Vector{Polynomial{ZZ/p}}, u::Polynomial{ZZZ})::w
 
 Assuming `vv` is an array of `r` factors of integer polynomial `u` modulo `p`,
 return an iterator over products of factors from `vv`.
@@ -639,7 +639,7 @@ function smallfactors(
     vv,
     u::P,
     mask = typemax(Int),
-) where P<:UnivariatePolynomial{<:ZZ{<:Integer}}
+) where P<:UnivariatePolynomial{<:ZI}
     r = length(vv)
     mask &= (1 << r - 1)
     rm = count_ones(mask)
@@ -795,7 +795,7 @@ function reduction(p::P) where P<:UnivariatePolynomial
     P(p.coeff, 0), kbest, best, nex
 end
 
-function ffactor(p::P) where P<:UnivariatePolynomial{<:ZZ}
+function ffactor(p::P) where P<:UnivariatePolynomial{<:ZI}
     #println("ffactor($p)")
     q, nord, n, nex = reduction(p)
     n == 1 && return factor(p)

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -27,8 +27,8 @@ function pivot(A::Union{AbstractMatrix,AbstractVector}, i::Integer, j::Integer =
     amax, imax
 end
 
-pivabs(a::QQ) = pivabs(ZZ(numerator(a)))
-pivabs(z::ZZ) = iszero(z) ? 0.0 : isunit(z) ? Inf : 1.0 / abs(z.val)
+pivabs(a::T) where T<:QQ = pivabs(basetype(T)(numerator(a)))
+pivabs(z::ZI) = iszero(z) ? 0.0 : isunit(z) ? Inf : 1.0 / abs(value(z))
 pivabs(a::Ring) = isunit(a) ? 1 : 0
 
 """
@@ -412,7 +412,7 @@ function adjugate(A::AbstractMatrix{P}) where P<:Ring
         _adjugate_fallback(A)
     end
 end
-function _adjugate(A::AbstractMatrix{P}, da) where P<:Union{Polynomial,ZZ}
+function _adjugate(A::AbstractMatrix{P}, da) where P<:Union{Polynomial,ZI}
     Q = Frac(P)
     B = Q.(A)
     C = inv(B) .* Q(da)

--- a/src/lll.jl
+++ b/src/lll.jl
@@ -177,7 +177,7 @@ end
 
 function minimal_polynomial(a::Number, n::Integer; e=1e-5, c=1e9)
     m = rational_relationship([a^i for i = 0:n]; e, c)
-    p = ZZ{Int}[:x](m)
+    p = ZZZ[:x](m)
     p / lcunit(p)
 end
 

--- a/src/numberfield.jl
+++ b/src/numberfield.jl
@@ -37,7 +37,7 @@ Base.convert(::Type{T}, a::Ring) where T<:NumberField = T(a)
 Base.convert(::Type{T}, a::NumberField) where T<:NumberField = a
 
 promote_rule(::Type{N}, ::Type{<:QQ}) where N<:NumberField = N
-promote_rule(::Type{N}, ::Type{<:ZZ}) where N<:NumberField = N
+promote_rule(::Type{N}, ::Type{<:ZI}) where N<:NumberField = N
 promote_rule(::Type{N}, ::Type{<:Integer}) where N<:NumberField = N
 promote_rule(::Type{N}, ::Type{<:Rational}) where N<:NumberField = N
 

--- a/src/numbertheoretical.jl
+++ b/src/numbertheoretical.jl
@@ -131,7 +131,7 @@ necklace(q::Union{BigInt,RingInt}, n::Integer) = n == 0 ? one(q) : _necklace(q, 
     _div(s, n)
 end
 _div(s, n) = div(s, n)
-_div(s::UnivariatePolynomial{Z,X}, n) where {X,Z<:ZZ} = QQ[X](s) / n
+_div(s::UnivariatePolynomial{Z,X}, n) where {X,Z<:ZI} = QQ[X](s) / n
 
 """
     carmichael(n::Integer)

--- a/src/promoteconvert.jl
+++ b/src/promoteconvert.jl
@@ -7,12 +7,7 @@ function promote_rule(::Type{T}, ::Type{S}) where {T<:Ring,S<:RingInt}
     (S <: T || S <: B) ? T : promote_type(B, S) == B ? T : Base.Bottom
 end
 _xpromote_rule(a::Type, b::Type) = promote_type(a, b)
-#=
-@generated function Base.promote_rule(a::Type{<:Ring}, b::Type{<:RingInt})
-    bt = _xpromote_rule(a.parameters[1], b.parameters[1])
-    :($bt)
-end
-=#
+
 function promote_rule(::Type{R}, ::Type{S}) where {R<:Ring,S<:Rational}
     promote_rule(R, promote_type(basetype(R), S))
 end
@@ -22,7 +17,7 @@ end
 
 # abstract float or complex involved
 promote_rule(::Type{A}, ::Type{<:QQ{B}}) where {A<:OtherNumber,B} = promote_type(A, B)
-promote_rule(::Type{A}, ::Type{<:ZZ{B}}) where {A<:OtherNumber,B} = promote_type(A, B)
+promote_rule(::Type{A}, B::Type{<:ZI}) where {A<:OtherNumber} = promote_type(A, basetype(B))
 
 # convertions
 convert(::Type{T}, a::S) where {T<:Ring, S<:T} = a
@@ -38,7 +33,7 @@ function convert(::Type{T}, a::S) where {T<:Ring,S<:Ring}
     end
 end
 
-function convert(::Type{A}, a::Union{ZZ,QQ}) where {A<:Number}
+function convert(::Type{A}, a::Union{ZI,QQ}) where {A<:Number}
     convert(A, value(a))
 end
 

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -80,7 +80,8 @@ for op in (:+, :-, :*)
 end
 ==(a::T, b::T) where T<:QQ = Rational(a) == Rational(b)
 /(a::T, b::T) where T<:QQ = iszero(b) ? throw(DivideError()) : QQ(Rational(a) / Rational(b))
--(a::QQ{T}) where T = QQ{T}(checked_neg(a.num), a.den)
+-(a::T) where T<:QQ{<:Integer} = T(checked_neg(a.num), a.den)
+-(a::T) where T = T(-a.num, a.den)
 divrem(a::T, b::T) where T<:QQ = (a / b, zero(T))
 div(a::T, b::T) where T<:QQ = a / b
 rem(a::T, b::T) where T<:QQ = zero(T)

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -24,7 +24,8 @@ QQ{T}(a::Integer) where T = QQ{T}(T(a), one(T), NOCHECK)
 QQ{T}(a::Rational{<:Integer}) where T = QQ{T}(T(a.num), T(a.den), NOCHECK)
 
 QQ(a::QQ{T}) where T = a
-QQ(a::T) where T<:ZI = QQ{basetype(T)}(a)
+QQ(a::T) where T<:ZZ = QQ{basetype(T)}(a)
+QQ(a::ZZZ) where T<:ZZ = QQ{ZZZ}(a)
 QQ(a::T) where T = QQ{T}(a)
 QQ(a::Rational{T}) where T<:Integer = QQ{T}(a)
 
@@ -75,17 +76,17 @@ end
 # operations for QQ
 for op in (:+, :-, :*)
     @eval begin
-        ($op)(a::QQ{T}, b::QQ{T}) where T = QQ(($op)(Rational(a), Rational(b)))
+        ($op)(a::T, b::T) where T<:QQ = T(($op)(value(a), value(b)))
     end
 end
-==(a::T, b::T) where T<:QQ = Rational(a) == Rational(b)
-/(a::T, b::T) where T<:QQ = iszero(b) ? throw(DivideError()) : QQ(Rational(a) / Rational(b))
+==(a::T, b::T) where T<:QQ = value(a) == value(b)
+/(a::T, b::T) where T<:QQ = iszero(b) ? throw(DivideError()) : T(value(a) / value(b))
 -(a::T) where T<:QQ{<:Integer} = T(checked_neg(a.num), a.den)
 -(a::T) where T<:QQ{<:Ring} = T(-a.num, a.den)
 divrem(a::T, b::T) where T<:QQ = (a / b, zero(T))
 div(a::T, b::T) where T<:QQ = a / b
-rem(a::T, b::T) where T<:QQ = zero(T)
-isless(a::T, b::T) where T<:QQ = isless(Rational(a), Rational(b))
+rem(::T, ::T) where T<:QQ = zero(T)
+isless(a::T, b::T) where T<:QQ = isless(value(a), value(b))
 
 isunit(a::QQ) = !iszero(a.num)
 isone(a::QQ) = a.num == a.den
@@ -93,7 +94,7 @@ iszero(a::QQ) = iszero(a.num)
 zero(::Type{QQ{T}}) where T = QQ{T}(zero(T), one(T), NOCHECK)
 one(::Type{QQ{T}}) where T = QQ{T}(one(T), one(T), NOCHECK)
 abs(a::QQ{T}) where T = QQ{T}(abs(a.num), abs(a.den), NOCHECK)
-hash(a::QQ, h::UInt) = hash(Rational(a), h)
+hash(a::QQ, h::UInt) = hash(value(a), h)
 
 function show(io::IO, a::QQ)
     if isone(a.den)

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -80,7 +80,7 @@ for op in (:+, :-, :*)
     end
 end
 ==(a::T, b::T) where T<:QQ = value(a) == value(b)
-/(a::T, b::T) where T<:QQ = iszero(b) ? throw(DivideError()) : T(value(a) / value(b))
+/(a::T, b::T) where T<:QQ = T(value(a) / value(b))
 -(a::T) where T<:QQ{<:Integer} = T(checked_neg(a.num), a.den)
 -(a::T) where T<:QQ{<:Ring} = T(-a.num, a.den)
 divrem(a::T, b::T) where T<:QQ = (a / b, zero(T))

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -1,28 +1,30 @@
 
 # class constructor
 QQ(::Type{T}) where T<:Integer = QQ{T}
-QQ(::Type{ZZ{T}}) where T = QQ{T}
+QQ(::Type{T}) where T<:ZI = QQ{basetype(T)}
 
-Base.big(::Type{<:QQ}) = QQ{BigInt}
+Base.big(::Type{Q}) where Q<:QQ = QQ{big(basetype(Q))}
 
 category_trait(::Type{<:QQ}) = FieldTrait
 Base.IteratorSize(::Type{<:QQ}) = IsInfinite()
 
 # construction
 basetype(::Type{<:QQ{T}}) where T = ZZ{T}
+basetype(::Type{<:QQ{T}}) where T<:ZI = T
 #depth(::Type{<:QQ}) = 1
 lcunit(a::QQ) = a < 0 ? -one(a) : one(a)
 issimpler(a::T, b::T) where T<:QQ = QQ(abs(a.num), a.den) < QQ(abs(b.num), b.den)
 copy(a::QQ) = typeof(a)(a.num, a.den)
-value(a::QQ) = Rational(a.num, a.den)
+
+value(a::QQ) = Rational(value(a.num), value(a.den))
 
 QQ{T}(a::QQ) where T = QQ{T}(T(a.num), T(a.den), NOCHECK)
-QQ{T}(a::ZZ) where T = QQ{T}(T(a.val), one(T), NOCHECK)
+QQ{T}(a::ZI) where T = QQ{T}(T(value(a)), one(T), NOCHECK)
 QQ{T}(a::Integer) where T = QQ{T}(T(a), one(T), NOCHECK)
 QQ{T}(a::Rational{<:Integer}) where T = QQ{T}(T(a.num), T(a.den), NOCHECK)
 
 QQ(a::QQ{T}) where T = a
-QQ(a::ZZ{T}) where T = QQ{T}(a)
+QQ(a::T) where T<:ZI = QQ{basetype(T)}(a)
 QQ(a::T) where T = QQ{T}(a)
 QQ(a::Rational{T}) where T<:Integer = QQ{T}(a)
 
@@ -46,18 +48,21 @@ function QQ(a::S, b::T) where {S<:Integer,T<:Integer}
     QQ{R}(R(a), R(b))
 end
 QQ(num::T, den::T) where T = QQ{T}(num, den)
-function QQ(num::ZZ, den::ZZ)
+function QQ(num::ZI, den::ZI)
     num, den = promote(num, den)
     QQ(value(num), value(den))
 end
-Base.Rational(a::QQ{T}) where T = Rational(a.num, a.den)
-//(a::ZZ{T}, b::ZZ{T}) where T = QQ(Rational(a.val, b.val))
-Base.float(a::R) where {R<:Union{ZZ,QQ}} = float(value(a))
-(::Type{T})(a::R) where {R<:Union{ZZ,QQ},T<:AbstractFloat} = T(value(a))
+
+value(a::Number) = a
+
+Base.Rational(a::QQ{T}) where T = Rational(value(a.num), value(a.den))
+//(a::T, b::T) where {T<:ZI} = QQ(Rational(value(a), value(b)))
+Base.float(a::R) where {R<:Union{ZI,QQ}} = float(value(a))
+(::Type{T})(a::R) where {R<:Union{ZI,QQ},T<:AbstractFloat} = T(value(a))
 
 # promotion and conversion
 promote_rule(::Type{QQ{T}}, ::Type{QQ{S}}) where {S,T} = QQ{promote_type(S, T)}
-promote_rule(::Type{QQ{T}}, ::Type{ZZ{S}}) where {S,T} = QQ{promote_type(S, T)}
+promote_rule(::Type{QQ{T}}, ::Type{S}) where {S<:ZI,T} = QQ{promote_type(basetype(S), T)}
 promote_rule(::Type{QQ{T}}, ::Type{S}) where {S<:Integer,T} = QQ{promote_type(S, T)}
 promote_rule(::Type{QQ{T}}, ::Type{Rational{S}}) where {S<:Integer,T} =
     QQ{promote_type(S, T)}

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -25,7 +25,7 @@ QQ{T}(a::Rational{<:Integer}) where T = QQ{T}(T(a.num), T(a.den), NOCHECK)
 
 QQ(a::QQ{T}) where T = a
 QQ(a::T) where T<:ZZ = QQ{basetype(T)}(a)
-QQ(a::ZZZ) where T<:ZZ = QQ{ZZZ}(a)
+QQ(a::T) where T<:ZZZ = QQ{ZZZ}(a)
 QQ(a::T) where T = QQ{T}(a)
 QQ(a::Rational{T}) where T<:Integer = QQ{T}(a)
 

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -81,7 +81,7 @@ end
 ==(a::T, b::T) where T<:QQ = Rational(a) == Rational(b)
 /(a::T, b::T) where T<:QQ = iszero(b) ? throw(DivideError()) : QQ(Rational(a) / Rational(b))
 -(a::T) where T<:QQ{<:Integer} = T(checked_neg(a.num), a.den)
--(a::T) where T = T(-a.num, a.den)
+-(a::T) where T<:QQ{<:Ring} = T(-a.num, a.den)
 divrem(a::T, b::T) where T<:QQ = (a / b, zero(T))
 div(a::T, b::T) where T<:QQ = a / b
 rem(a::T, b::T) where T<:QQ = zero(T)

--- a/src/quotient.jl
+++ b/src/quotient.jl
@@ -88,13 +88,10 @@ dimension(::Type{Quotient{R,I,X,Id}}) where {R,I,X,Id} = Id[2]
 isprimemod(::Type{<:Quotient{R,I,X,Id}}) where {R,I,X,Id} = Id[3]
 subfield(::Type{<:Quotient{R}}) where {Z,R<:UnivariatePolynomial{Z}} = Z
 
-@generated function order(a::Type{<:Quotient})
-    function _order(::Type{<:Type{Q}}) where {Q<:Quotient}
-        r = dimension(Q)
-        b = order(subfield(Q))
-        iszero(r * b) ? 0 : uptype(intpower(b, r), Int)
-    end
-    _order(a)
+function order(::Type{Q}) where {Q<:Quotient}
+    r = dimension(Q)
+    b = order(subfield(Q))
+    iszero(r * b) ? 0 : uptype(intpower(b, r), Int)
 end
 
 # induced homomorphism - invalid if Q = R/I and I not in kernel(F)

--- a/src/resultant.jl
+++ b/src/resultant.jl
@@ -195,9 +195,9 @@ function pgcdx(a::T, b::T) where {S,T<:UnivariatePolynomial{S}}
     cc, a, b = normgcd(a, b)
     ψ = -E
     β = iseven(d) ? E : -E
-    EE = one(T)
-    ZZ = zero(T)
-    s1, s2, t1, t2 = EE, ZZ, ZZ, EE
+    One = one(T)
+    Zero = zero(T)
+    s1, s2, t1, t2 = One, Zero, Zero, One
     while true
         γ = LC(b)
         γd = γ^(d + 1)

--- a/src/ringtypes.jl
+++ b/src/ringtypes.jl
@@ -196,10 +196,10 @@ end
 The quotient ring of `R` modulo `m` of type `I`, also written as `R / m`.
 `m` may be an ideal of `R` or a (list of) element(s) of `R` generating the ideal.
 Typically `m` is replaced by a symbolic `X`, and the actual `m` is given as argument(s)
-to the type constructor like  `new_class(Quotient{ZZ,`X`}, m...)`.
+to the type constructor like  `new_class(Quotient{ZZ,:X}, m...)`.
 If the `X` is omitted, an anonymous symbol is used.
 
-The preferred way of construction is via `Zm = Z/m`.
+The preferred way of construction is via `Zm = ZZ/m`.
 """
 struct Quotient{R<:Ring,I,X,Id} <: QuotientRing{R,QuotientClass{X,I}}
     val::R
@@ -322,7 +322,7 @@ end
 
 Union of all scalar and discrete types.
 """
-const RingNumber = Union{Integer,Rational,ZZZ,ZZ,QQ,ZZmod,GaloisField}
+const RingNumber = Union{Integer,Rational,ZI,QQ,ZZmod,GaloisField}
 
 # Categorial traits specify algebraic properties of ring types
 # (cf. https://en.wikipedia.org/wiki/Integral_domain)

--- a/src/ringtypes.jl
+++ b/src/ringtypes.jl
@@ -284,7 +284,7 @@ of a degree of the product of the degrees of the operands have to be factored in
 case.
 """
 struct AlgebraicNumber <: Ring{AlgebraicNumberClass}
-    minpol::UnivariatePolynomial{QQ{BigInt},:x}
+    minpol::UnivariatePolynomial{QQ{ZZZ},:x}
     roots::Vector{ComplexF64}
     rootid::Int
     approx::Complex{BigFloat}

--- a/src/univarpolynom.jl
+++ b/src/univarpolynom.jl
@@ -550,12 +550,12 @@ end
     primpart(p::Polynomial)
 
 The primitive part of the polynomial `p`, equals [`p / content(p)`](@ref).
-If the basetype is `QQ`, returned polynomial has basetype `ZZ`.
+If the basetype is `QQ`, returned polynomial has basetype of ZZ or ZZZ.
 """
 primpart(p::Polynomial) = p / content(p)
 function primpart(p::UnivariatePolynomial{Q,X}) where {Q<:Union{QQ,Frac},X}
-    Z = basetype(Q)
-    (Z[X])(Z.(numerator.((p / content(p)).coeff)), ord(p))
+    B = basetype(Q)
+    (B[X])(B.(numerator.((p / content(p)).coeff)), ord(p))
 end
 
 """
@@ -567,10 +567,10 @@ function content_primpart(p::Polynomial)
     c = content(p)
     c, p / c
 end
-function content_primpart(p::P) where {T,X,P<:UnivariatePolynomial{QQ{T},X}}
+function content_primpart(p::P) where {T,X,Q<:QQ{T},P<:UnivariatePolynomial{Q,X}}
     c = content(p)
-    Z = ZZ{T}
-    pp = Z[X]([Z(numerator(x / c)) for x in p.coeff], ord(p))
+    B = basetype(Q)
+    pp = B[X]([B(numerator(x / c)) for x in p.coeff], ord(p))
     c, pp
 end
 

--- a/src/univarpolynom.jl
+++ b/src/univarpolynom.jl
@@ -831,6 +831,19 @@ function companion(p::UnivariatePolynomial{S}, q::UnivariatePolynomial{T}) where
     A
 end
 
+# Here the comanion of a polynomial given by its vector
+function companion(::Type{S}, v::AbstractVector) where S
+    n = length(v) - 1
+    A = zeros(S, n, n)
+    u = -inv(v[n+1])
+    for i = 1:n-1
+        A[i+1,i] = oneunit(S)
+        A[i,n] = v[i] * u
+    end
+    A[n,n] = v[n] * u
+    A
+end
+
 ### Display functions
 
 import Base: show

--- a/src/zz.jl
+++ b/src/zz.jl
@@ -2,7 +2,7 @@
 # class constructors
 ZZ(::Type{T}) where T<:Integer = ZZ{T}
 
-Base.big(::Type{<:ZZ}) = ZZ{BigInt}
+Base.big(::Type{<:ZI}) = ZZZ
 
 # construction
 category_trait(::Type{<:ZZ}) = EuclidianDomainTrait

--- a/src/zzflint.jl
+++ b/src/zzflint.jl
@@ -15,6 +15,7 @@ iscoprime(a::T, b::T) where T<:ZZZ = gcd(a, b) == one(T)
 value(a::ZZZ) = BigInt(a)
 
 copy(a::ZZZ) = ZZZ(a)
+ZZZ(a::T) where T<:Bool = ZZZ(Int(a))
 ZZZ(a::T) where T<:Base.BitSignedSmall = ZZZ(Int(a))
 ZZZ(a::T) where T<:Base.BitUnsignedSmall = ZZZ(UInt(a))
 ZZZ(a::T) where T<:Base.BitInteger = ZZZ(BigInt(a))

--- a/src/zzflint.jl
+++ b/src/zzflint.jl
@@ -187,9 +187,10 @@ end
     end
 end
 
+throw_D() = throw(DivideError())
 
-divrem(a::T, b::T) where T<:ZZZ = divrem(a, b, RoundToZero)
-div(a::T, b::T) where T<:ZZZ = div(a, b, RoundToZero)
+divrem(a::T, b::T) where T<:ZZZ = !iszero(b) ? divrem(a, b, RoundToZero) : throw_D()
+div(a::T, b::T) where T<:ZZZ = !iszero(b) ? div(a, b, RoundToZero) : throw_D()
 
 isunit(a::ZZZ) = abs(a.d) == 1
 isone(a::ZZZ) = isone(a.d)

--- a/src/zzflint.jl
+++ b/src/zzflint.jl
@@ -28,13 +28,13 @@ function Base.divgcd(x::TX, y::TY)::Tuple{TX,TY} where {TX<:ZZZ,TY<:ZZZ}
 end
 rem(x::Union{Integer,ZZZ}, ::Type{<:ZZZ}) = ZZZ(x)
 
-function ZZZ(a::Union{QQ{T},Frac{ZZ{T}}}) where T
+function ZZZ(a::Union{QQ,Frac{<:ZI}})
     a.den != 1 && throw(InexactError(:ZZZ, ZZZ, a))
     ZZZ(a.num)
 end
 
 # promotion and conversion
-promote_rule(::Type{ZZZ}, ::Type{<:ZZ}) = ZZZ
+promote_rule(::Type{ZZZ}, ::Type{<:ZI}) = ZZZ
 promote_rule(::Type{ZZZ}, ::Type{QQ{S}}) where {S} = QQ{promote_type(S, BigInt)}
 promote_rule(::Type{ZZZ}, ::Type{S}) where {S<:Integer} = ZZZ
 promote_rule(::Type{ZZZ}, ::Type{R}) where {R<:Rational} =
@@ -55,7 +55,7 @@ end
 Base.isless(p::T, q::T) where T<:ZZZ = p < q
 Base.to_power_type(x::ZZZ) = x
 
-# operations for ZZ
+# operations for ZZZ
 
 fmpz(a...) = (Symbol(:fmpz_, a...), libflint)
 

--- a/src/zzmod.jl
+++ b/src/zzmod.jl
@@ -30,7 +30,7 @@ end
 ZZmod(a::T, m::S) where {T<:Integer,S<:Integer} = ZZmod(m, S)(S(a))
 ZZmod{m,T}(a::ZZmod{m,T}) where {m,T} = a
 ZZmod{m,T}(a::ZZmod{m,S}) where {m,T,S} = ZZmod{m,T}(a.val)
-ZZmod{m,T}(a::ZZ) where {m,T} = ZZmod{m,T}(a.val)
+ZZmod{m,T}(a::ZI) where {m,T} = ZZmod{m,T}(value(a))
 
 copy(p::ZZmod) = typeof(p)(p.val)
 
@@ -64,8 +64,8 @@ function (::Type{ZT})(a::ZS) where {n,m,T,S,ZT<:ZZmod{n,T},ZS<:ZZmod{m,S}}
     end
 end
 
-convert(::Type{Z}, a::ZZ) where Z<:ZZmod = Z(a)
-(::Type{Z})(a::ZZ) where Z<:ZZmod = Z(a.val % modulus(Z))
+convert(::Type{Z}, a::ZI) where Z<:ZZmod = Z(a)
+(::Type{Z})(a::ZI) where Z<:ZZmod = Z(value(a) % modulus(Z))
 (::Type{T})(a::ZZmod) where T<:Integer = T(value(a))
 
 """

--- a/test/algebraic.jl
+++ b/test/algebraic.jl
@@ -1,6 +1,8 @@
 module AlgebraicNumbers
 
 using CommutativeRings
+import CommutativeRings: SMALL_INT
+
 using Test
 
 P = QQ{BigInt}[:x]
@@ -97,7 +99,9 @@ end
     @test approx(c) ≈ op(approx(a), approx(b))
 end
 
-@testset "Algebraic $op($a,A) arithmetic" for op in (+, -, *, /), a in (0, 11, ZZ(11), ZZZ(11))
+@testset "Algebraic $op($a,A) arithmetic" for op in (+, -, *, /),
+    a in (0, 11, ZZ(11), ZZZ(11))
+
     a = big(a)
     b = AlgebraicNumber(x^3 + x + 1)
     c = op(a, b)
@@ -141,14 +145,24 @@ end
 end
 
 @testset "Algebraic - expressions" begin
-    expr2 = :(sqrt(-2))
+    expr2 = :(sqrt(-2 + 0im))
     @test AlgebraicNumber(expr2) == AlgebraicNumber(x^2 + 2, im)
 
     exprq = :(sqrt((11 / 12)^2))
-    @test AlgebraicNumber(exprq) == AlgebraicNumber(x - 11//12)
+    @test AlgebraicNumber(exprq) == AlgebraicNumber(x - 11 // 12)
 
     expr5 = :(sqrt(5) + 1)
     @test AlgebraicNumber(expr5) / 4 == cospi(QQ(1 // 5))
+
+    expr10 = :(sqrt(5 / 8 + sqrt(-5 / 16 + 25 / 64)))
+    @test AlgebraicNumber(expr10) == cospi(QQ(1 // 10))
+
+    expr17 = :(
+        1 - sqrt(17) +
+        sqrt(34 - sqrt(68)) +
+        sqrt(68 + sqrt(2448) + sqrt(2720 + sqrt(6284288)))
+    )
+    @test AlgebraicNumber(expr17) / 16 == cospi(QQ(1 // 17))
 
     expr217 = :(
         (
@@ -159,16 +173,42 @@ end
     )
     @test AlgebraicNumber(expr217) == cospi(QQ(2 // 17)) * 2
 
-    expr17 = :(
-        1 - sqrt(17) +
-        sqrt(34 - sqrt(68)) +
-        sqrt(68 + sqrt(2448) + sqrt(2720 + sqrt(6284288)))
-    )
-    @test AlgebraicNumber(expr17) / 16 == cospi(QQ(1 // 17))
-
     a = AlgebraicNumber(:((3^(1 // 3) - 6^(1 // 3) + 12^(1 // 3)) / 3))
     b = AlgebraicNumber(:((2^(1 // 3) - 1)^(1 // 3)))
     @test a == b
+end
+
+using Base.MathConstants
+@testset "arithmetic with float and complex constants and symbols" begin
+    @test AlgebraicNumber((SMALL_INT - 1) / SMALL_INT) ==
+          AlgebraicNumber((SMALL_INT - 1) // SMALL_INT)
+    @test AlgebraicNumber((SMALL_INT + 1) + 0.0) == AlgebraicNumber(SMALL_INT + 1)
+    @test AlgebraicNumber(1 / (SMALL_INT + 1)) == AlgebraicNumber(1 // (SMALL_INT + 1))
+    @test_throws InexactError AlgebraicNumber((SMALL_INT + 2) / (SMALL_INT + 1))
+    @test AlgebraicNumber(1 / 3) == AlgebraicNumber(1 // 3)
+    @test AlgebraicNumber(:(sqrt(2))) * 2.5 == AlgebraicNumber(:(5 / sqrt(2)))
+    a = AlgebraicNumber(im)
+    mp = minimal_polynomial(a)
+    x = monom(typeof(mp))
+    @test a == AlgebraicNumber(:im)
+    @test minimal_polynomial(a + 7 / 5) == mp(x - 7 // 5)
+    @test AlgebraicNumber(:(1 + im)) == AlgebraicNumber(im) + 1
+    @test_throws ArgumentError AlgebraicNumber(:(2.5 * im))
+    @test AlgebraicNumber(:(5.0 * im)) == AlgebraicNumber(im) * 5
+    @test AlgebraicNumber(:(sqrt(2) + 3^(3 / 4) * im)) ==
+          AlgebraicNumber(:(sqrt(2))) + AlgebraicNumber(:(sqrt(sqrt(3^3)))) * im
+    @test_throws Exception AlgebraicNumber(π)
+    @test_throws ArgumentError AlgebraicNumber(:π)
+    @test minimal_polynomial(AlgebraicNumber(:φ)) == x^2 - x - 1
+    @test minimal_polynomial(AlgebraicNumber(:(φ^-1))) == x^2 + x - 1
+    @test minimal_polynomial(AlgebraicNumber(:(φ^2))) == x^2 - 3x + 1
+end
+
+@testset "arithmetic with φ^[$n,$(n+1),$(-n),$(-n-1)]" for n in rand(1:1000, 1)
+    fib2(n) = fibonacci(n) * 2 + fibonacci(n - 3)
+    for m in (n, n + 1, -n, -n - 1)
+        @test minimal_polynomial(AlgebraicNumber(:(φ^$n))) == x^2 - fib2(n) * x + (-1)^n
+    end
 end
 
 @testset "exactness of pure imaginary roots" begin

--- a/test/algebraic.jl
+++ b/test/algebraic.jl
@@ -17,6 +17,14 @@ tol = eps(BigFloat) * 100
     a = AlgebraicNumber(p, s)
     @test minimal_polynomial(a) == p
     @test approx(a) ≈ r
+    @test 1 / AlgebraicNumber(0) == AlgebraicNumber(1//0)
+
+    @test_throws DivideError AlgebraicNumber(0) / AlgebraicNumber(0)
+    @test_throws DivideError AlgebraicNumber(1//0) / AlgebraicNumber(1//0)
+    @test inv(AlgebraicNumber(1//0)) == 0
+    @test isfinite(AlgebraicNumber(0))
+    @test !isfinite(AlgebraicNumber(1//0))
+    @test AlgebraicNumber(1//0) / AlgebraicNumber(0) == AlgebraicNumber(Inf)
 end
 
 @testset "Algebraic identities" begin
@@ -145,7 +153,7 @@ end
 end
 
 @testset "Algebraic - expressions" begin
-    expr2 = :(sqrt(-2 + 0im))
+    expr2 = :(sqrt(-2))
     @test AlgebraicNumber(expr2) == AlgebraicNumber(x^2 + 2, im)
 
     exprq = :(sqrt((11 / 12)^2))
@@ -180,10 +188,10 @@ end
 
 using Base.MathConstants
 @testset "arithmetic with float and complex constants and symbols" begin
-    @test AlgebraicNumber((SMALL_INT - 1) / SMALL_INT) ==
-          AlgebraicNumber((SMALL_INT - 1) // SMALL_INT)
+    @test AlgebraicNumber((SMALL_INT - 2) / (SMALL_INT - 1)) ==
+          AlgebraicNumber((SMALL_INT - 2) // (SMALL_INT - 1))
     @test AlgebraicNumber((SMALL_INT + 1) + 0.0) == AlgebraicNumber(SMALL_INT + 1)
-    @test AlgebraicNumber(1 / (SMALL_INT + 1)) == AlgebraicNumber(1 // (SMALL_INT + 1))
+    @test_throws InexactError AlgebraicNumber(1 / (SMALL_INT))
     @test_throws InexactError AlgebraicNumber((SMALL_INT + 2) / (SMALL_INT + 1))
     @test AlgebraicNumber(1 / 3) == AlgebraicNumber(1 // 3)
     @test AlgebraicNumber(:(sqrt(2))) * 2.5 == AlgebraicNumber(:(5 / sqrt(2)))
@@ -227,6 +235,7 @@ end
 @testset "cardano's formula $(x^3+a*x^2+b*x+c)" for (a, b, c) in (
     (1, -8, -6),
     (6, 9, 8),
+    (0, 0, 2),
     rand(-10:10, 3),
 )
     a, b, c = QQ.((a, b, c))
@@ -236,7 +245,7 @@ end
 
     da = sqrt(AlgebraicNumber((q / 2)^2 + (p / 3)^3))
     ua = (da - q / 2)^(1 // 3)
-    va = (-p / 3) / ua # (-da - q / 2)^(1 // 3)
+    va = p != 0 ? (-p / 3) / ua : (-da - q / 2)^(1 // 3)
     e3 = cispi(QQ(2 // 3))
     @test ua * va == -p / 3
 

--- a/test/algebraic.jl
+++ b/test/algebraic.jl
@@ -97,7 +97,7 @@ end
     @test approx(c) ≈ op(approx(a), approx(b))
 end
 
-@testset "Algebraic $op($a,A) arithmetic" for op in (+, -, *, /), a in (0, 11, ZZ(11))
+@testset "Algebraic $op($a,A) arithmetic" for op in (+, -, *, /), a in (0, 11, ZZ(11), ZZZ(11))
     a = big(a)
     b = AlgebraicNumber(x^3 + x + 1)
     c = op(a, b)

--- a/test/determinant.jl
+++ b/test/determinant.jl
@@ -4,16 +4,16 @@ using Test
 using CommutativeRings
 import CommutativeRings: det_DJB, det_QR, det_Bird, det_MV
 
-Z = ZZ / (2^2 * 3 * 5)
+X = ZZ / (2^2 * 3 * 5)
 @testset "determinant division free $i" for (i, a) in enumerate((
     [2 3 5; 3 3 2; 10 2 3],
     [2 3 3 4; 4 0 4 2; 2 3 0 4; 3 3 4 2],
     [-6 4 -11 9; -2 21 -16 25; 21 2 24 -25; 24 -23 2 2],
 ))
 
-    A = Z.(a)
+    A = X.(a)
     res = det_Bird(A)
-    @test res isa Z
+    @test res isa X
     @test_throws AssertionError("category_trait(D) <: IntegralDomainTrait") det_DJB(A)
     @test det_QR(A) == res
     @test det_MV(A) == res

--- a/test/fraction.jl
+++ b/test/fraction.jl
@@ -25,7 +25,7 @@ import CommutativeRings.mult_by_monom
     @test F(pq2) == pq
     @test F(13) == F(13, 1)
     @test F(ZZ(11)) == F(ZZ(22), ZZ(2))
-    @test basetype(Frac(Int8(11))) == ZZ{Int8}
+    @test basetype(Frac(Int8(11))) <: ZI
 
     @test convert(F, pq) === pq
     @test convert(F, pq2) == pq2


### PR DESCRIPTION
Make type ZZZ more prominent.

Added functionality for AlgebraicNumbers.

BREAKING change: The Expression, which can be used to define an AlgebraicNumber must now be evaluable.
